### PR TITLE
docs: remove internal tracking identifiers from design and plan docs

### DIFF
--- a/docs/superpowers/plans/2026-04-16-cli-ux-features.md
+++ b/docs/superpowers/plans/2026-04-16-cli-ux-features.md
@@ -1605,18 +1605,9 @@ Errors are highlighted. Supports --json, --table, and --wide."
 
 ---
 
-### Task 6: Update beans to in-progress
+### Task 6: Final verification
 
-- [ ] **Step 1: Mark all four beans as in-progress**
-
-```bash
-pt beans update gt-u9ff -s in-progress
-pt beans update gt-ilzd -s in-progress
-pt beans update gt-r4mh -s in-progress
-pt beans update gt-m6bl -s in-progress
-```
-
-- [ ] **Step 2: Run final full test suite**
+- [ ] **Step 1: Run final full test suite**
 
 ```bash
 cargo test 2>&1
@@ -1624,7 +1615,7 @@ cargo test 2>&1
 
 Expected: All tests pass (existing + new).
 
-- [ ] **Step 3: Manual smoke test**
+- [ ] **Step 2: Manual smoke test**
 
 ```bash
 cq tools --wide

--- a/docs/superpowers/plans/2026-04-16-cq-context-flags.md
+++ b/docs/superpowers/plans/2026-04-16-cq-context-flags.md
@@ -8,8 +8,6 @@
 
 **Tech Stack:** Rust, clap 4 (derive), DuckDB (window functions, CTEs, `ANY_VALUE`), assert_cmd for integration tests.
 
-**Bean:** gt-rwd0
-
 ---
 
 ## Design Decisions (locked)
@@ -1110,45 +1108,19 @@ git commit -m "docs: document -A/-B/-C context flags"
 
 ---
 
-## Task 8: Update bean and close work
-
-**Files:**
-- Bean `gt-rwd0`
+## Task 8: Final verification and PR
 
 - [ ] **Step 1: Verify all tests pass**
 
 Run: `cargo test`
 Expected: all green, no skipped tests.
 
-- [ ] **Step 2: Update bean with summary of what shipped**
+- [ ] **Step 2: Push branch and open PR**
 
 ```bash
-pt beans update gt-rwd0 --status completed -d "Shipped in gt-rwd0/context-flags branch.
-
-## What shipped
-- -A N / -B N / -C N flags on cq tools and cq messages
-- Message-level context within session boundaries
-- Table output: dimmed context rows + -- separators between non-contiguous groups
-- JSON output: heterogeneous rows with match_kind and match_group fields; match rows on cq tools retain tool-specific columns (name, input, tool_use_id)
-- --count-by + context flags errors out with a clear message
-- --limit applies to match count (grep -m semantics)
-- Integration tests covering session boundary, limit semantics, conflict errors, JSON/TTY shapes
-
-## Related
-- See gt-w3eu for the skill-injection investigation that motivated this"
+git push -u origin <branch>
+gh pr create
 ```
-
-- [ ] **Step 3: Commit any remaining bean state and push**
-
-```bash
-git status
-# If there are pending changes:
-git add <bean file path if changed>
-git commit -m "chore: mark gt-rwd0 complete"
-git push -u origin gt-rwd0/context-flags
-```
-
-- [ ] **Step 4: Open PR** (use `pt pr create` or `gh pr create`)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-16-cli-ux-features-design.md
+++ b/docs/superpowers/specs/2026-04-16-cli-ux-features-design.md
@@ -2,8 +2,6 @@
 
 Four features that improve cq's output control and aggregation capabilities.
 
-Related beans: gt-u9ff, gt-ilzd, gt-r4mh, gt-m6bl
-
 ## Design Principles
 
 ### `--fields` is column selection everywhere
@@ -157,7 +155,7 @@ Valid views: messages, tool_calls, tool_results, sessions
 - `src/scope.rs`: improve `--since` and `--session` error messages
 - `src/commands/schema.rs`: align error format
 
-## Feature 1: `--wide` flag and TTY detection (gt-u9ff)
+## Feature 1: `--wide` flag and TTY detection
 
 ### CLI
 
@@ -194,7 +192,7 @@ Thread `wide` into each command's `run()` function, which passes it to render fu
 - `src/commands/messages.rs`: thread wide to render functions
 - `src/commands/sessions.rs`: thread wide to render functions
 
-## Feature 2: `--fields` on messages and sessions (gt-ilzd)
+## Feature 2: `--fields` on messages and sessions
 
 ### CLI
 
@@ -231,7 +229,7 @@ This differs from `tools --fields` which builds `json_extract_string` expression
 - `src/commands/messages.rs`: add field validation, modify SELECT when fields specified
 - `src/commands/sessions.rs`: add field validation, modify SELECT when fields specified
 
-## Feature 3: `--count-by` aggregation (gt-r4mh)
+## Feature 3: `--count-by` aggregation
 
 ### CLI
 
@@ -285,7 +283,7 @@ When `--count-by` is present, build an aggregation query instead of a detail que
 - `src/commands/messages.rs`: add aggregation path, validate column name
 - `src/commands/sessions.rs`: add aggregation path, validate column name
 
-## Feature 4: Session timeline (gt-m6bl)
+## Feature 4: Session timeline
 
 ### CLI
 


### PR DESCRIPTION
## Summary

- The CLI UX feature design spec and two companion plan docs had a handful of opaque work-item identifiers (`Bean: X`, `Related beans: ...`) and workflow snippets that only mean something inside my personal task tracker. Removed them.
- No technical content changed. Feature headings now read cleanly without the parenthetical IDs, and the "update the tracker" tasks collapsed into the verification/PR steps they were already adjacent to.

## Test plan

- Nothing to run here. `grep -rn 'gt-[a-z0-9]\{4\}'` on the tree is empty after the change, and the rendered docs still make sense on their own.
