### PR TITLE
Support cq --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Run `cq schema --examples` for a query cookbook.
 | `--no-color` | | Disable colored output |
 | `--limit <n>` | | Max results (default: 50, 0 for unlimited) |
 | `--offset <n>` | | Skip first N results |
+| `--version` | `-V` | Print the cq version |
 | `-A N` | | Show N messages after each match (messages, tools) |
 | `-B N` | | Show N messages before each match (messages, tools) |
 | `-C N` | | Shorthand for `-A N -B N` (messages, tools) |

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use cq::output::OutputFormat;
 use cq::scope::QueryScope;
 
 #[derive(Parser)]
-#[command(name = "cq", about = "Query AI agent session transcripts with SQL")]
+#[command(name = "cq", version, about = "Query AI agent session transcripts with SQL")]
 struct Cli {
     /// Scope to a project (substring match, e.g. 'myproject')
     #[arg(short = 'p', long, global = true)]


### PR DESCRIPTION
## Summary

`cq --version` errored with "unexpected argument '--version'" because clap's version was never wired up. This adds `version` to the command attribute so `--version` and `-V` report the binary version from the Cargo package.

This is the CLI binary version (from Cargo.toml), independent of the plugin/skill version in `plugin.json`.

## Test plan

- `cq --version` and `cq -V` both print `cq 0.1.0`
- `cargo test` passes (125 tests)
