### PR TITLE
Index sessions across cenv environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Run `cq schema --examples` for a query cookbook.
 | `-B N` | | Show N messages before each match (messages, tools) |
 | `-C N` | | Shorthand for `-A N -B N` (messages, tools) |
 
+## Sources
+
+cq indexes multiple transcript **sources**: the main config dir (`~/.claude/projects`, or `$CQ_PROJECTS_DIR`) plus every cenv env's `projects/` (discovered under `$CENV_BASE`, default `~/.local/share/cenv`). A cenv env is one kind of source; cq never shells out to cenv.
+
+By default cq scopes to the **active** source (the one matching `$CLAUDE_CONFIG_DIR`, else `main`), mirroring how it auto-scopes to the current directory. Use `--all` to span every source and `--source <name>` to target one. Every row carries a `source` column; compose with `--since` to weigh results by age.
+
+| Flag | What it does |
+|------|-------------|
+| _(default)_ | Scope to the active source |
+| `--source <name>` | Target one source by name (e.g. `main`, or a cenv env name) |
+| `--all` | Span all sources |
+
 ## Views
 
 Four SQL views, all queryable with `cq sql`:

--- a/claude-plugin/skills/cq/SKILL.md
+++ b/claude-plugin/skills/cq/SKILL.md
@@ -23,7 +23,8 @@ user_invocable: true
 
 - `--project <NAME>` - Substring match on project name
 - `--session <ID>` - Session ID (full UUID required, validates format)
-- `--all` - Show all projects (disable auto-scoping to current directory)
+- `--source <NAME>` - Scope to a named source (`main`, or a cenv env name); use `--all` to span every source. Every row carries a `source` column.
+- `--all` - Show all projects and all sources (disable auto-scoping)
 - `--since <DURATION>` - Time filter (e.g. `7d`, `24h`, `30m`)
 - `--json` - Machine-readable JSON output
 - `--table` - Aligned table with header

--- a/claude-plugin/skills/cq/SKILL.md
+++ b/claude-plugin/skills/cq/SKILL.md
@@ -39,13 +39,13 @@ user_invocable: true
 
 ## View Schemas
 
-**sessions**: session_id, project, started_at, ended_at, message_count, tool_call_count, user_message_count, subagent_count, first_user_message (counts are main-loop only)
+**sessions**: session_id, project, source, started_at, ended_at, message_count, tool_call_count, user_message_count, subagent_count, first_user_message (counts are main-loop only)
 
-**messages**: session_id, project, uuid, parent_uuid, type, timestamp, text, tool_count, model, agent_id, is_sidechain, agent_type, workflow_id
+**messages**: session_id, project, source, uuid, parent_uuid, type, timestamp, text, tool_count, model, agent_id, is_sidechain, agent_type, workflow_id
 
-**tool_calls**: session_id, project, message_uuid, tool_use_id, name, input (JSON), timestamp, agent_id, is_sidechain, agent_type, workflow_id
+**tool_calls**: session_id, project, source, message_uuid, tool_use_id, name, input (JSON), timestamp, agent_id, is_sidechain, agent_type, workflow_id
 
-**tool_results**: session_id, project, tool_use_id, is_error, content, agent_id, is_sidechain, agent_type, workflow_id
+**tool_results**: session_id, project, source, tool_use_id, is_error, content, agent_id, is_sidechain, agent_type, workflow_id
 
 Subagent rows carry the parent `session_id`. Filter with `WHERE NOT is_sidechain` (main loop), `WHERE is_sidechain` (subagents), `WHERE agent_type = 'Explore'`, or `WHERE workflow_id IS NOT NULL`.
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use duckdb::Connection;
 use duckdb::OptionalExt;
 
-pub const SCHEMA_VERSION: i32 = 3;
+pub const SCHEMA_VERSION: i32 = 4;
 
 /// Open or create the cache database. Creates tables if missing,
 /// rebuilds if schema version mismatches or force_rebuild is true.
@@ -80,6 +80,7 @@ fn rebuild(conn: &Connection) -> Result<()> {
             file_size BIGINT NOT NULL,
             cwd TEXT,
             agent_type TEXT,
+            source TEXT,
             indexed_at TIMESTAMP DEFAULT current_timestamp
         );
 

--- a/src/claude_provider.rs
+++ b/src/claude_provider.rs
@@ -1,31 +1,58 @@
 use std::path::{Path, PathBuf};
-use anyhow::{Context, Result};
+use anyhow::Result;
 use duckdb::Connection;
 use crate::provider::{TranscriptProvider, ProjectInfo};
 use crate::scope::QueryScope;
+use crate::source::{self, Source};
 use crate::views;
 
 pub struct ClaudeProvider {
-    base_dir: PathBuf,
+    sources: Vec<Source>,
 }
 
 impl ClaudeProvider {
+    /// Build the full source list: main + discovered cenv envs.
     pub fn new() -> Result<Self> {
-        let base_dir = if let Ok(dir) = std::env::var("CQ_PROJECTS_DIR") {
-            PathBuf::from(dir)
-        } else {
-            let home = dirs::home_dir().context("Could not determine home directory")?;
-            home.join(".claude").join("projects")
-        };
-        Ok(Self { base_dir })
+        let mut sources = vec![source::main_source()?];
+        sources.extend(source::discover_cenv_sources());
+        Ok(Self { sources })
     }
 
+    /// Construct from an explicit source list (tests, and future config-listed sources).
+    pub fn with_sources(sources: Vec<Source>) -> Self {
+        Self { sources }
+    }
+
+    /// Single-source constructor kept for existing tests. Names the source `main`.
     pub fn new_with_base(base_dir: PathBuf) -> Self {
-        Self { base_dir }
+        Self { sources: vec![Source { name: "main".to_string(), projects_dir: base_dir }] }
     }
 
-    pub fn base_dir(&self) -> &Path {
-        &self.base_dir
+    pub fn sources(&self) -> &[Source] {
+        &self.sources
+    }
+
+    /// The directories the indexer should scan, one per source.
+    pub fn projects_dirs(&self) -> Vec<PathBuf> {
+        self.sources.iter().map(|s| s.projects_dir.clone()).collect()
+    }
+
+    /// The source name a transcript file belongs to: the source whose
+    /// `projects_dir` is a prefix of the file path. None if no source matches.
+    pub fn source_for_file(&self, file: &Path) -> Option<String> {
+        self.sources
+            .iter()
+            .find(|s| file.starts_with(&s.projects_dir))
+            .map(|s| s.name.clone())
+    }
+
+    /// The source whose `projects_dir` lies under `config_dir` (the env dir from
+    /// CLAUDE_CONFIG_DIR), if any. Used to pick the active source.
+    pub fn source_for_config_dir(&self, config_dir: &Path) -> Option<String> {
+        self.sources
+            .iter()
+            .find(|s| s.projects_dir.starts_with(config_dir))
+            .map(|s| s.name.clone())
     }
 
     pub fn encode_path(path: &str) -> String {
@@ -40,25 +67,23 @@ impl ClaudeProvider {
         }
     }
 
-    fn matches_project(&self, encoded_name: &str, query: &str) -> bool {
+    fn matches_project(encoded_name: &str, query: &str) -> bool {
         let decoded = Self::decode_path(encoded_name);
         decoded.to_lowercase().contains(&query.to_lowercase())
     }
 
-    /// Given a project query string (as passed to --project), return the
-    /// matching project directories on disk. Used by SyncScope::Projects.
+    /// Project dirs (across all sources) whose decoded name matches the query.
+    /// Used by SyncScope::Projects.
     pub fn project_dirs_for_query(&self, query: &str) -> Vec<PathBuf> {
         let mut dirs = Vec::new();
-        if !self.base_dir.exists() {
-            return dirs;
-        }
-        if let Ok(entries) = std::fs::read_dir(&self.base_dir) {
+        for src in &self.sources {
+            let Ok(entries) = std::fs::read_dir(&src.projects_dir) else { continue };
             for entry in entries.filter_map(|e| e.ok()) {
                 if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                     continue;
                 }
                 let dir_name = entry.file_name().to_string_lossy().to_string();
-                if self.matches_project(&dir_name, query) {
+                if Self::matches_project(&dir_name, query) {
                     dirs.push(entry.path());
                 }
             }
@@ -66,24 +91,15 @@ impl ClaudeProvider {
         dirs
     }
 
-    /// Given a directory path, find the matching project name if one exists.
-    /// Checks if the encoded form of `cwd` (or any parent) matches a project directory.
+    /// Find a project path matching `cwd` (or a parent) in ANY source.
     pub fn project_for_cwd(&self, cwd: &str) -> Option<String> {
-        if !self.base_dir.exists() {
-            return None;
-        }
-
-        // Try the exact path first, then walk up parent directories
         let mut path = std::path::Path::new(cwd);
         loop {
             let encoded = Self::encode_path(&path.to_string_lossy());
-            let project_dir = self.base_dir.join(&encoded);
-            if project_dir.is_dir() {
-                // Return the original path, not the decoded version.
-                // encode_path is lossy (both '/' and '.' become '-'), so
-                // decode_path won't roundtrip correctly for paths with dots.
-                // The project column in views uses the original cwd from JSONL.
-                return Some(path.to_string_lossy().to_string());
+            for src in &self.sources {
+                if src.projects_dir.join(&encoded).is_dir() {
+                    return Some(path.to_string_lossy().to_string());
+                }
             }
             match path.parent() {
                 Some(parent) if parent != path => path = parent,
@@ -101,33 +117,37 @@ impl TranscriptProvider for ClaudeProvider {
 
     fn discover_files(&self, scope: &QueryScope) -> Result<Vec<PathBuf>> {
         let mut files = Vec::new();
-        if !self.base_dir.exists() {
-            return Ok(files);
-        }
-
-        let project_dirs: Vec<_> = std::fs::read_dir(&self.base_dir)?
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-            .collect();
-
-        for entry in project_dirs {
-            let dir_name = entry.file_name().to_string_lossy().to_string();
-            if let Some(ref project) = scope.project {
-                if !self.matches_project(&dir_name, project) {
+        for src in &self.sources {
+            if let Some(ref want) = scope.source {
+                if &src.name != want {
                     continue;
                 }
             }
-            let project_path = entry.path();
-            let mut found = Vec::new();
-            collect_jsonl_paths(&project_path, &mut found);
-            for path in found {
-                if let Some(ref session) = scope.session {
-                    let sid = session_id_for_file(&project_path, &path);
-                    if !sid.starts_with(session.as_str()) {
+            if !src.projects_dir.exists() {
+                continue;
+            }
+            let project_dirs = std::fs::read_dir(&src.projects_dir)?
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false));
+            for entry in project_dirs {
+                let dir_name = entry.file_name().to_string_lossy().to_string();
+                if let Some(ref project) = scope.project {
+                    if !Self::matches_project(&dir_name, project) {
                         continue;
                     }
                 }
-                files.push(path);
+                let project_path = entry.path();
+                let mut found = Vec::new();
+                collect_jsonl_paths(&project_path, &mut found);
+                for path in found {
+                    if let Some(ref session) = scope.session {
+                        let sid = session_id_for_file(&project_path, &path);
+                        if !sid.starts_with(session.as_str()) {
+                            continue;
+                        }
+                    }
+                    files.push(path);
+                }
             }
         }
         Ok(files)
@@ -139,26 +159,23 @@ impl TranscriptProvider for ClaudeProvider {
 
     fn list_projects(&self) -> Result<Vec<ProjectInfo>> {
         let mut projects = Vec::new();
-        if !self.base_dir.exists() {
-            return Ok(projects);
-        }
-
-        for entry in std::fs::read_dir(&self.base_dir)? {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
-                continue;
+        for src in &self.sources {
+            let Ok(entries) = std::fs::read_dir(&src.projects_dir) else { continue };
+            for entry in entries.filter_map(|e| e.ok()) {
+                if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let encoded_name = entry.file_name().to_string_lossy().to_string();
+                let decoded_path = Self::decode_path(&encoded_name);
+                let file_count = std::fs::read_dir(entry.path())
+                    .map(|rd| {
+                        rd.filter_map(|e| e.ok())
+                            .filter(|e| e.path().extension().map(|ext| ext == "jsonl").unwrap_or(false))
+                            .count()
+                    })
+                    .unwrap_or(0);
+                projects.push(ProjectInfo { encoded_name, decoded_path, file_count });
             }
-            let encoded_name = entry.file_name().to_string_lossy().to_string();
-            let decoded_path = Self::decode_path(&encoded_name);
-            let file_count = std::fs::read_dir(entry.path())?
-                .filter_map(|e| e.ok())
-                .filter(|e| e.path().extension().map(|ext| ext == "jsonl").unwrap_or(false))
-                .count();
-            projects.push(ProjectInfo {
-                encoded_name,
-                decoded_path,
-                file_count,
-            });
         }
         projects.sort_by(|a, b| b.file_count.cmp(&a.file_count));
         Ok(projects)
@@ -374,6 +391,53 @@ mod tests {
             .discover_files(&QueryScope::new(None, Some("abc12345".to_string()), None))
             .unwrap();
         assert_eq!(scoped.len(), 2);
+    }
+
+    #[test]
+    fn discover_files_unions_across_sources() {
+        use crate::source::Source;
+        let tmp = TempDir::new().unwrap();
+        let main_dir = tmp.path().join("main").join("projects");
+        let env_dir = tmp.path().join("cenv").join("pinwheel").join("projects");
+        let main_proj = main_dir.join("-Users-josh-a");
+        let env_proj = env_dir.join("-Users-josh-b");
+        fs::create_dir_all(&main_proj).unwrap();
+        fs::create_dir_all(&env_proj).unwrap();
+        fs::write(main_proj.join("11111111-0000-0000-0000-000000000000.jsonl"), "{}").unwrap();
+        fs::write(env_proj.join("22222222-0000-0000-0000-000000000000.jsonl"), "{}").unwrap();
+
+        let provider = ClaudeProvider::with_sources(vec![
+            Source { name: "main".into(), projects_dir: main_dir.clone() },
+            Source { name: "pinwheel".into(), projects_dir: env_dir.clone() },
+        ]);
+
+        let files = provider.discover_files(&QueryScope::new(None, None, None)).unwrap();
+        assert_eq!(files.len(), 2);
+
+        // source_for_file maps a path back to its source name
+        let f = files.iter().find(|p| p.to_string_lossy().contains("pinwheel")).unwrap();
+        assert_eq!(provider.source_for_file(f).as_deref(), Some("pinwheel"));
+    }
+
+    #[test]
+    fn source_scope_filters_to_one_source() {
+        use crate::source::Source;
+        let tmp = TempDir::new().unwrap();
+        let main_dir = tmp.path().join("main").join("projects");
+        let env_dir = tmp.path().join("cenv").join("pinwheel").join("projects");
+        fs::create_dir_all(main_dir.join("-a")).unwrap();
+        fs::create_dir_all(env_dir.join("-b")).unwrap();
+        fs::write(main_dir.join("-a").join("s.jsonl"), "{}").unwrap();
+        fs::write(env_dir.join("-b").join("s.jsonl"), "{}").unwrap();
+
+        let provider = ClaudeProvider::with_sources(vec![
+            Source { name: "main".into(), projects_dir: main_dir },
+            Source { name: "pinwheel".into(), projects_dir: env_dir },
+        ]);
+        let scope = QueryScope::new(None, None, None).with_source(Some("pinwheel".into()));
+        let files = provider.discover_files(&scope).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].to_string_lossy().contains("pinwheel"));
     }
 
     #[test]

--- a/src/commands/messages.rs
+++ b/src/commands/messages.rs
@@ -76,6 +76,11 @@ pub fn run(
         params.push(Box::new(session.clone()));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("timestamp >= '{formatted}'"));
@@ -173,6 +178,9 @@ fn run_with_context(
     }
     if let Some(_session) = &scope.session {
         scope_conditions.push("session_id = ?".to_string());
+    }
+    if scope.source.is_some() {
+        scope_conditions.push("source = ?".to_string());
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -280,6 +288,11 @@ fn run_with_fields(
         params.push(Box::new(session.clone()));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("timestamp >= '{formatted}'"));
@@ -336,6 +349,11 @@ fn run_count_by(
     if let Some(session) = &scope.session {
         conditions.push("session_id = ?".to_string());
         params.push(Box::new(session.clone()));
+    }
+
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -192,6 +192,9 @@ pub fn print_no_results(scope: &crate::scope::QueryScope, extra_filters: &[&str]
     if scope.since.is_some() {
         active.push("--since".to_string());
     }
+    if scope.source.is_some() {
+        active.push("--source".to_string());
+    }
     for f in extra_filters {
         active.push(f.to_string());
     }
@@ -236,8 +239,8 @@ pub fn print_truncation_hint(
 
 /// Build the parameter vector corresponding to the scope WHERE clause fragments
 /// used in the `ordered` CTE and `matches_subquery`. Order matters, must match the
-/// order in which scope_conditions are pushed: project, then session. `since` is
-/// inlined into the SQL string so it contributes no params.
+/// order in which scope_conditions are pushed: project, then session, then source.
+/// `since` is inlined into the SQL string so it contributes no params.
 pub fn build_scope_params(scope: &crate::scope::QueryScope) -> Vec<Box<dyn duckdb::types::ToSql>> {
     let mut params: Vec<Box<dyn duckdb::types::ToSql>> = Vec::new();
     if let Some(project) = &scope.project {
@@ -245,6 +248,9 @@ pub fn build_scope_params(scope: &crate::scope::QueryScope) -> Vec<Box<dyn duckd
     }
     if let Some(session) = &scope.session {
         params.push(Box::new(session.clone()));
+    }
+    if let Some(source) = &scope.source {
+        params.push(Box::new(source.clone()));
     }
     params
 }

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -8,6 +8,7 @@ use crate::style;
 
 struct ProjectRow {
     project: String,
+    source: String,
     sessions: i64,
     messages: i64,
     tools: i64,
@@ -17,6 +18,7 @@ struct ProjectRow {
 
 struct SkillRow {
     project: String,
+    source: String,
     skill: String,
 }
 
@@ -57,6 +59,12 @@ pub fn run(
     offset: usize,
     _wide: bool,
 ) -> Result<()> {
+    // When the user did not scope to one source, the same repo path can exist
+    // under multiple sources. Group by (source, project) so they show as distinct
+    // rows and surface a SOURCE column. When scoped to one source, group by
+    // project alone (source is constant, so the column is redundant).
+    let group_by_source = scope.source.is_none();
+
     let mut conditions = vec!["1=1".to_string()];
     let mut params: Vec<Box<dyn duckdb::types::ToSql>> = Vec::new();
 
@@ -81,17 +89,19 @@ pub fn run(
     let offset_clause = super::offset_clause(offset);
 
     if matches!(format, OutputFormat::Json) {
-        // JSON mode: include skill list per project
+        // JSON mode: include skill list per project. Always carry source so the
+        // field is present regardless of scope. Group by (source, project).
         let sql = format!(
             "SELECT
                 s.project,
+                s.source,
                 count(DISTINCT s.session_id) as sessions,
                 cast(sum(s.message_count) as BIGINT) as messages,
                 cast(sum(s.tool_call_count) as BIGINT) as tools,
                 max(s.ended_at) as last_activity
             FROM sessions s
             WHERE {where_clause}
-            GROUP BY s.project
+            GROUP BY s.project, s.source
             ORDER BY last_activity DESC
             {limit_clause}
             {offset_clause}"
@@ -104,18 +114,22 @@ pub fn run(
 
         while let Some(row) = rows_iter.next()? {
             let project = row.get::<_, String>(0).unwrap_or_default();
-            let sessions = val_i64(&row.get::<_, Value>(1).unwrap_or(Value::Null));
-            let messages = val_i64(&row.get::<_, Value>(2).unwrap_or(Value::Null));
-            let tools = val_i64(&row.get::<_, Value>(3).unwrap_or(Value::Null));
-            let last_activity = row.get::<_, String>(4).unwrap_or_default();
+            let source = row.get::<_, String>(1).unwrap_or_default();
+            let sessions = val_i64(&row.get::<_, Value>(2).unwrap_or(Value::Null));
+            let messages = val_i64(&row.get::<_, Value>(3).unwrap_or(Value::Null));
+            let tools = val_i64(&row.get::<_, Value>(4).unwrap_or(Value::Null));
+            let last_activity = row.get::<_, String>(5).unwrap_or_default();
 
-            // Fetch skills for this project
+            // Fetch skills for this (source, project): a Skill tool_call in one
+            // source must not inflate another source's skill list.
             let skill_sql = "SELECT DISTINCT json_extract_string(input, '$.skill') as skill
                 FROM tool_calls
-                WHERE name = 'Skill' AND project = ?
+                WHERE name = 'Skill' AND project = ? AND source = ?
                 ORDER BY skill";
             let mut skill_stmt = conn.prepare(skill_sql)?;
-            let mut skill_iter = skill_stmt.query(&[&project as &dyn duckdb::types::ToSql])?;
+            let mut skill_iter = skill_stmt.query(
+                &[&project as &dyn duckdb::types::ToSql, &source as &dyn duckdb::types::ToSql],
+            )?;
             let mut skills: Vec<String> = Vec::new();
             while let Some(skill_row) = skill_iter.next()? {
                 let s = skill_row.get::<_, String>(0).unwrap_or_default();
@@ -126,6 +140,7 @@ pub fn run(
 
             json_rows.push(serde_json::json!({
                 "project": project,
+                "source": source,
                 "sessions": sessions,
                 "messages": messages,
                 "tools": tools,
@@ -139,40 +154,77 @@ pub fn run(
         return Ok(());
     }
 
-    // Query project aggregates with skill count via subquery
+    // Query project aggregates with a per-(source, project) skill-count CTE.
+    //
+    // A correlated subquery in the SELECT list would put its `?` BEFORE the outer
+    // WHERE's placeholders, making param ordering fragile. A CTE keeps the skill
+    // pre-aggregation source-correct AND keeps params readable: the CTE's optional
+    // `source = ?` is the FIRST placeholder in the SQL text, so we push it first.
+    //
+    // The CTE always groups skills by (source, project). The join key includes
+    // source so a Skill call in one source can't inflate another source's count.
+    let skill_cte_filter = if scope.source.is_some() {
+        "AND source = ?"
+    } else {
+        ""
+    };
+
+    // Params in SQL-text order: 1) CTE source filter (if scoped), 2) outer WHERE
+    // params (project ILIKE, then outer source) as already collected in `params`.
+    let mut agg_params: Vec<Box<dyn duckdb::types::ToSql>> = Vec::new();
+    if let Some(source) = &scope.source {
+        agg_params.push(Box::new(source.clone()));
+    }
+    if let Some(project) = &scope.project {
+        agg_params.push(Box::new(format!("%{project}%")));
+    }
+    if let Some(source) = &scope.source {
+        agg_params.push(Box::new(source.clone()));
+    }
+
     let sql = format!(
-        "SELECT
+        "WITH skill_counts AS (
+            SELECT source, project,
+                   count(DISTINCT json_extract_string(input, '$.skill')) as skills
+            FROM tool_calls
+            WHERE name = 'Skill' {skill_cte_filter}
+            GROUP BY source, project
+        )
+        SELECT
             s.project,
+            s.source,
             count(DISTINCT s.session_id) as sessions,
             cast(sum(s.message_count) as BIGINT) as messages,
             cast(sum(s.tool_call_count) as BIGINT) as tools,
-            (SELECT count(DISTINCT json_extract_string(tc.input, '$.skill'))
-             FROM tool_calls tc
-             WHERE tc.name = 'Skill' AND tc.project = s.project) as skills,
+            COALESCE(max(sc.skills), 0) as skills,
             max(s.ended_at) as last_activity
         FROM sessions s
+        LEFT JOIN skill_counts sc
+            ON sc.project = s.project AND sc.source = s.source
         WHERE {where_clause}
-        GROUP BY s.project
+        GROUP BY s.project, s.source
         ORDER BY last_activity DESC
         {limit_clause}
         {offset_clause}"
     );
 
+    let agg_param_refs: Vec<&dyn duckdb::types::ToSql> = agg_params.iter().map(|p| p.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
-    let mut rows_iter = stmt.query(&param_refs[..])?;
+    let mut rows_iter = stmt.query(&agg_param_refs[..])?;
     let mut project_rows: Vec<ProjectRow> = Vec::new();
 
     while let Some(row) = rows_iter.next()? {
-        let values: Vec<Value> = (0..6)
+        let values: Vec<Value> = (0..7)
             .map(|i| row.get::<_, Value>(i).unwrap_or(Value::Null))
             .collect();
         project_rows.push(ProjectRow {
             project: val_str(&values[0]),
-            sessions: val_i64(&values[1]),
-            messages: val_i64(&values[2]),
-            tools: val_i64(&values[3]),
-            skills: val_i64(&values[4]),
-            last_activity: val_str(&values[5]),
+            source: val_str(&values[1]),
+            sessions: val_i64(&values[2]),
+            messages: val_i64(&values[3]),
+            tools: val_i64(&values[4]),
+            skills: val_i64(&values[5]),
+            last_activity: val_str(&values[6]),
         });
     }
 
@@ -181,23 +233,28 @@ pub fn run(
         return Ok(());
     }
 
-    // Fetch skill names if --skills flag
+    // Fetch skill names if --skills flag. Keyed on (source, project) so a skill
+    // call in one source doesn't show up under another source's row.
     let skill_rows = if show_skills {
-        let projects: Vec<&str> = project_rows.iter().map(|r| r.project.as_str()).collect();
-        fetch_skills(conn, &projects)?
+        let pairs: Vec<(&str, &str)> = project_rows
+            .iter()
+            .map(|r| (r.source.as_str(), r.project.as_str()))
+            .collect();
+        fetch_skills(conn, scope.source.as_deref(), &pairs)?
     } else {
         vec![]
     };
 
     match format {
-        OutputFormat::Table => render_table(&project_rows, &skill_rows, show_skills),
-        _ => render_oneline(&project_rows, &skill_rows, show_skills),
+        OutputFormat::Table => render_table(&project_rows, &skill_rows, show_skills, group_by_source),
+        _ => render_oneline(&project_rows, &skill_rows, show_skills, group_by_source),
     }
 
-    // Truncation hint (inline because projects counts distinct, not rows)
+    // Truncation hint (inline because projects counts distinct, not rows).
+    // We group by (source, project), so count distinct (source, project) pairs.
     if limit > 0 && project_rows.len() >= limit {
         let count_sql = format!(
-            "SELECT COUNT(DISTINCT s.project) FROM sessions s WHERE {where_clause}"
+            "SELECT COUNT(DISTINCT (s.source, s.project)) FROM sessions s WHERE {where_clause}"
         );
         if let Ok(total) = conn.query_row(&count_sql, &param_refs[..], |row| row.get::<_, i64>(0)) {
             let total = total as usize;
@@ -213,26 +270,43 @@ pub fn run(
     Ok(())
 }
 
-fn fetch_skills(conn: &Connection, projects: &[&str]) -> Result<Vec<SkillRow>> {
-    if projects.is_empty() {
+/// Fetch skill names per (source, project). `source_filter` restricts the scan
+/// to one source when the user scoped with --source; `pairs` is the set of
+/// (source, project) rows to keep. Keying on (source, project) keeps a Skill
+/// call in one source from appearing under another source's row.
+fn fetch_skills(
+    conn: &Connection,
+    source_filter: Option<&str>,
+    pairs: &[(&str, &str)],
+) -> Result<Vec<SkillRow>> {
+    if pairs.is_empty() {
         return Ok(vec![]);
     }
 
-    let sql = "SELECT project, json_extract_string(input, '$.skill') as skill
-        FROM tool_calls
-        WHERE name = 'Skill'
-        GROUP BY project, skill
-        ORDER BY project, skill";
+    let (filter_sql, params): (&str, Vec<Box<dyn duckdb::types::ToSql>>) = match source_filter {
+        Some(src) => ("AND source = ?", vec![Box::new(src.to_string())]),
+        None => ("", vec![]),
+    };
 
-    let mut stmt = conn.prepare(sql)?;
-    let mut rows_iter = stmt.query([])?;
+    let sql = format!(
+        "SELECT source, project, json_extract_string(input, '$.skill') as skill
+        FROM tool_calls
+        WHERE name = 'Skill' {filter_sql}
+        GROUP BY source, project, skill
+        ORDER BY source, project, skill"
+    );
+
+    let param_refs: Vec<&dyn duckdb::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows_iter = stmt.query(&param_refs[..])?;
     let mut skills: Vec<SkillRow> = Vec::new();
 
     while let Some(row) = rows_iter.next()? {
-        let project = row.get::<_, String>(0).unwrap_or_default();
-        let skill = row.get::<_, String>(1).unwrap_or_default();
-        if !skill.is_empty() && projects.contains(&project.as_str()) {
-            skills.push(SkillRow { project, skill });
+        let source = row.get::<_, String>(0).unwrap_or_default();
+        let project = row.get::<_, String>(1).unwrap_or_default();
+        let skill = row.get::<_, String>(2).unwrap_or_default();
+        if !skill.is_empty() && pairs.contains(&(source.as_str(), project.as_str())) {
+            skills.push(SkillRow { project, source, skill });
         }
     }
 
@@ -247,7 +321,8 @@ fn format_count(n: i64) -> String {
     }
 }
 
-fn render_oneline(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: bool) {
+fn render_oneline(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: bool, show_source: bool) {
+    // Column order: last_activity, project, [source], sessions, messages, tools, skills.
     let plain_rows: Vec<Vec<String>> = rows.iter().map(|r| {
         let time_ago = if r.last_activity.is_empty() {
             style::null_display().to_string()
@@ -266,10 +341,19 @@ fn render_oneline(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: boo
         let tools = format!("{} tools", format_count(r.tools));
         let skills = format!("{} skills", r.skills);
 
-        vec![time_ago, project, sessions, messages, tools, skills]
+        let mut cols = vec![time_ago, project];
+        if show_source {
+            cols.push(if r.source.is_empty() {
+                style::null_display().to_string()
+            } else {
+                r.source.clone()
+            });
+        }
+        cols.extend([sessions, messages, tools, skills]);
+        cols
     }).collect();
 
-    let ncols = 6;
+    let ncols = if show_source { 7 } else { 6 };
     let mut widths = vec![0usize; ncols];
     for row in &plain_rows {
         for (i, cell) in row.iter().enumerate() {
@@ -279,6 +363,8 @@ fn render_oneline(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: boo
         }
     }
 
+    // project is at index 1 (Primary); the source column (when shown) at index 2
+    // uses Secondary; everything else is Dim.
     for (idx, row) in plain_rows.iter().enumerate() {
         let cols: Vec<String> = row.iter().enumerate().map(|(i, cell)| {
             let padded = if i == ncols - 1 {
@@ -286,19 +372,20 @@ fn render_oneline(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: boo
             } else {
                 style::pad_right(cell, widths[i])
             };
-            match i {
-                0 => style::color(&padded, style::Color::Dim),
-                1 => style::color(&padded, style::Color::Primary),
-                _ => style::color(&padded, style::Color::Dim),
-            }
+            let color = match i {
+                1 => style::Color::Primary,
+                2 if show_source => style::Color::Secondary,
+                _ => style::Color::Dim,
+            };
+            style::color(&padded, color)
         }).collect();
         println!("{}", cols.join("  "));
 
         if show_skills {
-            let project = &rows[idx].project;
+            let r = &rows[idx];
             let skills: Vec<&str> = skill_rows
                 .iter()
-                .filter(|s| s.project == *project)
+                .filter(|s| s.project == r.project && s.source == r.source)
                 .map(|s| s.skill.as_str())
                 .collect();
             if !skills.is_empty() {
@@ -313,12 +400,15 @@ fn render_oneline(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: boo
     }
 }
 
-fn render_table(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: bool) {
-    let headers = if show_skills {
-        vec!["last_activity", "project", "sessions", "messages", "tools", "skills", "skill_names"]
-    } else {
-        vec!["last_activity", "project", "sessions", "messages", "tools", "skills"]
-    };
+fn render_table(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: bool, show_source: bool) {
+    let mut headers: Vec<&str> = vec!["last_activity", "project"];
+    if show_source {
+        headers.push("source");
+    }
+    headers.extend(["sessions", "messages", "tools", "skills"]);
+    if show_skills {
+        headers.push("skill_names");
+    }
 
     let string_rows: Vec<Vec<String>> = rows.iter().map(|r| {
         let time_ago = if r.last_activity.is_empty() {
@@ -333,19 +423,25 @@ fn render_table(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: bool)
             project_leaf(&r.project)
         };
 
-        let mut row = vec![
-            time_ago,
-            project,
+        let mut row = vec![time_ago, project];
+        if show_source {
+            row.push(if r.source.is_empty() {
+                style::null_display().to_string()
+            } else {
+                r.source.clone()
+            });
+        }
+        row.extend([
             r.sessions.to_string(),
             format_count(r.messages),
             format_count(r.tools),
             r.skills.to_string(),
-        ];
+        ]);
 
         if show_skills {
             let skills: Vec<&str> = skill_rows
                 .iter()
-                .filter(|s| s.project == r.project)
+                .filter(|s| s.project == r.project && s.source == r.source)
                 .map(|s| s.skill.as_str())
                 .collect();
             row.push(skills.join(", "));
@@ -354,6 +450,5 @@ fn render_table(rows: &[ProjectRow], skill_rows: &[SkillRow], show_skills: bool)
         row
     }).collect();
 
-    let header_refs: Vec<&str> = headers.iter().map(|s| *s).collect();
-    style::print_light_table(&header_refs, &string_rows);
+    style::print_light_table(&headers, &string_rows);
 }

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -65,6 +65,11 @@ pub fn run(
         params.push(Box::new(format!("%{project}%")));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("s.source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("s.started_at >= '{formatted}'"));

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -29,6 +29,7 @@ const MESSAGES_SCHEMA: &str = r#"messages
 --------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name (directory containing the JSONL file)
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   uuid                VARCHAR   Message UUID
   parent_uuid         VARCHAR   Parent message UUID
   type                VARCHAR   'user' or 'assistant'
@@ -45,6 +46,7 @@ const TOOL_CALLS_SCHEMA: &str = r#"tool_calls
 ----------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   message_uuid        VARCHAR   UUID of the containing assistant message
   tool_use_id         VARCHAR   Unique tool use ID (matches tool_results.tool_use_id)
   name                VARCHAR   Tool name (e.g. 'Bash', 'Read', 'Edit', 'Skill')
@@ -62,6 +64,7 @@ const TOOL_RESULTS_SCHEMA: &str = r#"tool_results
 ------------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   tool_use_id         VARCHAR   Matches tool_calls.tool_use_id
   is_error            BOOLEAN   true if the tool call returned an error
   content             VARCHAR   Tool result content (text)
@@ -74,6 +77,7 @@ const SESSIONS_SCHEMA: &str = r#"sessions
 --------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   started_at          VARCHAR   Timestamp of first message
   ended_at            VARCHAR   Timestamp of last message
   message_count       BIGINT    Total messages in session
@@ -147,6 +151,7 @@ messages
 --------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name (directory containing the JSONL file)
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   uuid                VARCHAR   Message UUID
   parent_uuid         VARCHAR   Parent message UUID
   type                VARCHAR   'user' or 'assistant'
@@ -163,6 +168,7 @@ tool_calls
 ----------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   message_uuid        VARCHAR   UUID of the containing assistant message
   tool_use_id         VARCHAR   Unique tool use ID (matches tool_results.tool_use_id)
   name                VARCHAR   Tool name (e.g. 'Bash', 'Read', 'Edit', 'Skill')
@@ -180,6 +186,7 @@ tool_results
 ------------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   tool_use_id         VARCHAR   Matches tool_calls.tool_use_id
   is_error            BOOLEAN   true if the tool call returned an error
   content             VARCHAR   Tool result content (text)
@@ -192,6 +199,7 @@ sessions
 --------
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
+  source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
   started_at          VARCHAR   Timestamp of first message
   ended_at            VARCHAR   Timestamp of last message
   message_count       BIGINT    Total messages in session

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -111,6 +111,11 @@ pub fn run(
         params.push(Box::new(session.clone()));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("started_at >= '{formatted}'"));
@@ -210,6 +215,11 @@ fn run_with_fields(
         params.push(Box::new(session.clone()));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("started_at >= '{formatted}'"));
@@ -260,6 +270,11 @@ fn run_count_by(
     if let Some(session) = &scope.session {
         conditions.push("session_id = ?".to_string());
         params.push(Box::new(session.clone()));
+    }
+
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -9,6 +9,7 @@ use crate::style;
 struct SessionRow {
     session_id: String,
     project: String,
+    source: String,
     started_at: String,
     ended_at: String,
     message_count: i64,
@@ -131,7 +132,7 @@ pub fn run(
     let offset_clause = super::offset_clause(offset);
 
     let sql = format!(
-        "SELECT session_id, project, started_at, ended_at, message_count, tool_call_count, first_user_message
+        "SELECT session_id, project, source, started_at, ended_at, message_count, tool_call_count, first_user_message
          FROM sessions
          WHERE {where_clause}
          ORDER BY started_at DESC
@@ -142,23 +143,28 @@ pub fn run(
     let param_refs: Vec<&dyn duckdb::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
 
+    // Show the SOURCE column only when results can span multiple sources
+    // (i.e. the user did not scope to one). Scoped to a single source it is redundant.
+    let show_source = scope.source.is_none();
+
     match format {
         OutputFormat::Json => output::print_results(&mut stmt, &param_refs, format, wide),
         _ => {
             let mut rows_iter = stmt.query(&param_refs[..])?;
             let mut session_rows: Vec<SessionRow> = Vec::new();
             while let Some(row) = rows_iter.next()? {
-                let values: Vec<Value> = (0..7)
+                let values: Vec<Value> = (0..8)
                     .map(|i| row.get::<_, Value>(i).unwrap_or(Value::Null))
                     .collect();
                 session_rows.push(SessionRow {
                     session_id: val_str(&values[0]),
                     project: val_str(&values[1]),
-                    started_at: val_str(&values[2]),
-                    ended_at: val_str(&values[3]),
-                    message_count: val_i64(&values[4]),
-                    tool_call_count: val_i64(&values[5]),
-                    first_user_message: val_str(&values[6]),
+                    source: val_str(&values[2]),
+                    started_at: val_str(&values[3]),
+                    ended_at: val_str(&values[4]),
+                    message_count: val_i64(&values[5]),
+                    tool_call_count: val_i64(&values[6]),
+                    first_user_message: val_str(&values[7]),
                 });
             }
 
@@ -174,8 +180,8 @@ pub fn run(
             }
 
             match format {
-                OutputFormat::Table => render_table(&session_rows, wide),
-                _ => render_oneline(&session_rows, wide),
+                OutputFormat::Table => render_table(&session_rows, wide, show_source),
+                _ => render_oneline(&session_rows, wide, show_source),
             }
 
             super::print_truncation_hint(
@@ -328,8 +334,9 @@ fn run_count_by(
     }
 }
 
-fn render_oneline(rows: &[SessionRow], wide: bool) {
-    // Build plain text rows (no color) for width calculation
+fn render_oneline(rows: &[SessionRow], wide: bool, show_source: bool) {
+    // Build plain text rows (no color) for width calculation.
+    // Column order: started, project, [source], session_id, dur, msgs, tools, first_msg.
     let plain_rows: Vec<Vec<String>> = rows.iter().map(|r| {
         let time_ago = if r.started_at.is_empty() {
             style::null_display().to_string()
@@ -366,11 +373,20 @@ fn render_oneline(rows: &[SessionRow], wide: bool) {
             style::truncate(&r.first_user_message, 60)
         };
 
-        vec![time_ago, project, session_id, duration, msg_count, tool_count, first_msg]
+        let mut cols = vec![time_ago, project];
+        if show_source {
+            cols.push(if r.source.is_empty() {
+                style::null_display().to_string()
+            } else {
+                r.source.clone()
+            });
+        }
+        cols.extend([session_id, duration, msg_count, tool_count, first_msg]);
+        cols
     }).collect();
 
     // Calculate column widths from plain text
-    let ncols = 7;
+    let ncols = if show_source { 8 } else { 7 };
     let mut widths = vec![0usize; ncols];
     for row in &plain_rows {
         for (i, cell) in row.iter().enumerate() {
@@ -380,6 +396,18 @@ fn render_oneline(rows: &[SessionRow], wide: bool) {
         }
     }
 
+    // Color index per logical column. The source column (when shown) sits at
+    // index 2 and uses the same Primary tone as project; the rest shift by one.
+    let color_for = |i: usize| -> style::Color {
+        let logical = if show_source && i >= 2 { if i == 2 { return style::Color::Primary; } i - 1 } else { i };
+        match logical {
+            0 => style::Color::Dim,        // started
+            1 => style::Color::Primary,    // project
+            2 => style::Color::Secondary,  // session_id
+            _ => style::Color::Dim,        // dur, msgs, tools
+        }
+    };
+
     // Print each row with color applied after padding
     for row in &plain_rows {
         let cols: Vec<String> = row.iter().enumerate().map(|(i, cell)| {
@@ -388,22 +416,22 @@ fn render_oneline(rows: &[SessionRow], wide: bool) {
             } else {
                 style::pad_right(cell, widths[i])
             };
-            match i {
-                0 => style::color(&padded, style::Color::Dim),
-                1 => style::color(&padded, style::Color::Primary),
-                2 => style::color(&padded, style::Color::Secondary),
-                3 => style::color(&padded, style::Color::Dim),
-                4 => style::color(&padded, style::Color::Dim),
-                5 => style::color(&padded, style::Color::Dim),
-                _ => padded, // last column, no color
+            if i == ncols - 1 {
+                padded // last column (first_user_message), no color
+            } else {
+                style::color(&padded, color_for(i))
             }
         }).collect();
         println!("{}", cols.join("  "));
     }
 }
 
-fn render_table(rows: &[SessionRow], wide: bool) {
-    let headers = ["started", "project", "session_id", "dur", "msgs", "tools", "first_user_message"];
+fn render_table(rows: &[SessionRow], wide: bool, show_source: bool) {
+    let headers: Vec<&str> = if show_source {
+        vec!["started", "project", "source", "session_id", "dur", "msgs", "tools", "first_user_message"]
+    } else {
+        vec!["started", "project", "session_id", "dur", "msgs", "tools", "first_user_message"]
+    };
 
     let string_rows: Vec<Vec<String>> = rows.iter().map(|r| {
         let started = if r.started_at.is_empty() {
@@ -441,7 +469,16 @@ fn render_table(rows: &[SessionRow], wide: bool) {
             style::truncate(&r.first_user_message, 60)
         };
 
-        vec![started, project, session_id, duration, msg_count, tool_count, first_msg]
+        let mut row = vec![started, project];
+        if show_source {
+            row.push(if r.source.is_empty() {
+                style::null_display().to_string()
+            } else {
+                r.source.clone()
+            });
+        }
+        row.extend([session_id, duration, msg_count, tool_count, first_msg]);
+        row
     }).collect();
 
     style::print_light_table(&headers, &string_rows);

--- a/src/commands/tools.rs
+++ b/src/commands/tools.rs
@@ -91,6 +91,11 @@ pub fn run(
         params.push(Box::new(session.clone()));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("tc.source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("tc.timestamp >= '{formatted}'"));
@@ -238,6 +243,9 @@ fn run_with_context(
     if scope.session.is_some() {
         scope_conditions.push("session_id = ?".to_string());
     }
+    if scope.source.is_some() {
+        scope_conditions.push("source = ?".to_string());
+    }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         scope_conditions.push(format!("timestamp >= '{formatted}'"));
@@ -253,6 +261,9 @@ fn run_with_context(
     }
     if scope.session.is_some() {
         tool_conditions.push("tc.session_id = ?".to_string());
+    }
+    if scope.source.is_some() {
+        tool_conditions.push("tc.source = ?".to_string());
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -489,6 +500,11 @@ fn run_count_by(
     if let Some(session) = &scope.session {
         conditions.push("tc.session_id = ?".to_string());
         params.push(Box::new(session.clone()));
+    }
+
+    if let Some(source) = &scope.source {
+        conditions.push("tc.source = ?".to_string());
+        params.push(Box::new(source.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/commands/tools.rs
+++ b/src/commands/tools.rs
@@ -588,6 +588,11 @@ fn run_summary(conn: &Connection, scope: &QueryScope, format: &OutputFormat, wid
         params.push(Box::new(session.clone()));
     }
 
+    if let Some(source) = &scope.source {
+        conditions.push("source = ?".to_string());
+        params.push(Box::new(source.clone()));
+    }
+
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         conditions.push(format!("timestamp >= '{formatted}'"));

--- a/src/db.rs
+++ b/src/db.rs
@@ -38,7 +38,7 @@ impl Default for DbOptions {
 ///
 /// Uses the persistent cache for fast incremental startup.
 pub fn setup_connection(
-    projects_dir: &std::path::Path,
+    sources: &[(String, std::path::PathBuf)],
     options: &DbOptions,
     scope: SyncScope,
 ) -> Result<DbSetup> {
@@ -46,7 +46,7 @@ pub fn setup_connection(
     let force_rebuild = options.sync_mode == SyncMode::Force;
     let conn = cache::open(&cache_dir, force_rebuild)?;
 
-    let result = indexer::sync(&conn, projects_dir, options.sync_mode, scope, &cache_dir)?;
+    let result = indexer::sync_sources(&conn, sources, options.sync_mode, scope, &cache_dir)?;
     let file_count = result.stats.added + result.stats.changed;
 
     views::register_derived_views(&conn)?;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -31,64 +31,45 @@ struct FileInfo {
     file_size: i64,
 }
 
-/// Sync the cache with the filesystem.
-///
-/// Behavior depends on `mode`:
-/// - `Auto`: check directory mtimes, try-lock, skip if nothing changed or lock busy
-/// - `Force`: always scan, wait for lock with timeout
-/// - `Skip`: return immediately without touching the database
-pub fn sync(
+/// Sync the cache against multiple sources. Auto mode checks the max dir mtime
+/// across all sources, takes the lock once, syncs each source, and writes
+/// last_sync_at a single time so one source's write can't suppress another's scan.
+pub fn sync_sources(
     conn: &Connection,
-    projects_dir: &Path,
+    sources: &[(String, PathBuf)],
     mode: SyncMode,
     scope: SyncScope,
     cache_dir: &Path,
 ) -> Result<SyncResult> {
-    // Skip mode: return immediately
     if mode == SyncMode::Skip {
-        return Ok(SyncResult {
-            stats: SyncStats::default(),
-            skipped: true,
-            lock_busy: false,
-        });
+        return Ok(SyncResult { stats: SyncStats::default(), skipped: true, lock_busy: false });
     }
 
-    // Auto mode: check if anything changed via directory mtimes
     if mode == SyncMode::Auto {
         let last_sync = cache::last_sync_at(conn)?;
-        let max_mtime = max_dir_mtime(projects_dir, &scope)?;
+        let mut max_mtime = 0i64;
+        for (_, dir) in sources {
+            let m = max_dir_mtime(dir, &scope)?;
+            if m > max_mtime { max_mtime = m; }
+        }
         if max_mtime <= last_sync {
             let total = count_registry(conn)?;
-            return Ok(SyncResult {
-                stats: SyncStats { total, ..Default::default() },
-                skipped: false,
-                lock_busy: false,
-            });
+            return Ok(SyncResult { stats: SyncStats { total, ..Default::default() }, skipped: false, lock_busy: false });
         }
     }
 
-    // Acquire file lock
     let lock_path = cache_dir.join("index.lock");
     let lock_file = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
+        .create(true).write(true).truncate(false).open(&lock_path)
         .context("Failed to open lock file")?;
 
     let lock_acquired = match mode {
-        SyncMode::Auto => {
-            lock_file.try_lock_exclusive().is_ok()
-        }
+        SyncMode::Auto => lock_file.try_lock_exclusive().is_ok(),
         SyncMode::Force => {
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
             loop {
-                if lock_file.try_lock_exclusive().is_ok() {
-                    break true;
-                }
-                if std::time::Instant::now() >= deadline {
-                    break false;
-                }
+                if lock_file.try_lock_exclusive().is_ok() { break true; }
+                if std::time::Instant::now() >= deadline { break false; }
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
         }
@@ -100,35 +81,29 @@ pub fn sync(
             anyhow::bail!("index locked by another process after 5s, try again shortly");
         }
         let total = count_registry(conn)?;
-        return Ok(SyncResult {
-            stats: SyncStats { total, ..Default::default() },
-            skipped: true,
-            lock_busy: true,
-        });
+        return Ok(SyncResult { stats: SyncStats { total, ..Default::default() }, skipped: true, lock_busy: true });
     }
 
-    // Lock acquired, do the full scan
-    let stats = do_sync(conn, projects_dir, &scope)?;
+    let mut agg = SyncStats::default();
+    for (name, dir) in sources {
+        let s = do_sync(conn, dir, &scope, name)?;
+        agg.added += s.added;
+        agg.removed += s.removed;
+        agg.changed += s.changed;
+    }
+    agg.total = count_registry(conn)?;
 
-    // Update last_sync_at on success
     let now_ns = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos() as i64)
-        .unwrap_or(0);
+        .map(|d| d.as_nanos() as i64).unwrap_or(0);
     cache::set_last_sync_at(conn, now_ns)?;
 
-    // Release lock
     let _ = lock_file.unlock();
-
-    Ok(SyncResult {
-        stats,
-        skipped: false,
-        lock_busy: false,
-    })
+    Ok(SyncResult { stats: agg, skipped: false, lock_busy: false })
 }
 
 /// The actual sync logic, extracted so the lock wraps it cleanly.
-fn do_sync(conn: &Connection, projects_dir: &Path, scope: &SyncScope) -> Result<SyncStats> {
+fn do_sync(conn: &Connection, projects_dir: &Path, scope: &SyncScope, source_name: &str) -> Result<SyncStats> {
     let disk_files = scan_filesystem(projects_dir, scope)?;
     let registry = load_registry(conn)?;
 
@@ -167,7 +142,7 @@ fn do_sync(conn: &Connection, projects_dir: &Path, scope: &SyncScope) -> Result<
     }
 
     if !to_add.is_empty() {
-        index_files(conn, &to_add)?;
+        index_files(conn, &to_add, source_name)?;
     }
 
     stats.total = if matches!(scope, SyncScope::All) {
@@ -372,7 +347,7 @@ fn max_mtime_recursive(dir: &Path) -> i64 {
 
 /// Parse JSONL files with DuckDB's read_json and insert into raw_records.
 /// Also extracts cwd and registers files in file_registry.
-fn index_files(conn: &Connection, files: &[PathBuf]) -> Result<()> {
+fn index_files(conn: &Connection, files: &[PathBuf], source_name: &str) -> Result<()> {
     for file in files {
         let path_str = file.to_string_lossy().to_string();
         let escaped = path_str.replace('\'', "''");
@@ -411,8 +386,8 @@ fn index_files(conn: &Connection, files: &[PathBuf]) -> Result<()> {
         let file_size = metadata.len() as i64;
 
         conn.execute(
-            "INSERT INTO file_registry (file_path, mtime_ns, file_size, cwd, agent_type) VALUES (?, ?, ?, ?, ?)",
-            duckdb::params![path_str, mtime_ns, file_size, cwd, agent_type],
+            "INSERT INTO file_registry (file_path, mtime_ns, file_size, cwd, agent_type, source) VALUES (?, ?, ?, ?, ?, ?)",
+            duckdb::params![path_str, mtime_ns, file_size, cwd, agent_type, source_name],
         )?;
     }
     Ok(())
@@ -424,6 +399,37 @@ mod tests {
     use crate::sync_scope::SyncScope;
     use std::time::Duration;
     use tempfile::TempDir;
+
+    #[test]
+    fn sync_sources_records_source_name() {
+        use crate::cache;
+        let cache_tmp = TempDir::new().unwrap();
+        let conn = cache::open(cache_tmp.path(), true).unwrap();
+
+        let main_tmp = TempDir::new().unwrap();
+        let env_tmp = TempDir::new().unwrap();
+        let main_proj = main_tmp.path().join("-Users-josh-a");
+        let env_proj = env_tmp.path().join("-Users-josh-b");
+        std::fs::create_dir_all(&main_proj).unwrap();
+        std::fs::create_dir_all(&env_proj).unwrap();
+        std::fs::write(main_proj.join("s1.jsonl"), "{\"cwd\":\"/x\"}\n").unwrap();
+        std::fs::write(env_proj.join("s2.jsonl"), "{\"cwd\":\"/y\"}\n").unwrap();
+
+        let sources = vec![
+            ("main".to_string(), main_tmp.path().to_path_buf()),
+            ("pinwheel".to_string(), env_tmp.path().to_path_buf()),
+        ];
+        sync_sources(&conn, &sources, SyncMode::Force, SyncScope::All, cache_tmp.path()).unwrap();
+
+        let n_pinwheel: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_registry WHERE source = 'pinwheel'", [], |r| r.get(0))
+            .unwrap();
+        let n_main: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_registry WHERE source = 'main'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_pinwheel, 1);
+        assert_eq!(n_main, 1);
+    }
 
     #[test]
     fn max_dir_mtime_detects_deep_new_file() {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -86,7 +86,24 @@ pub fn sync_sources(
 
     let mut agg = SyncStats::default();
     for (name, dir) in sources {
-        let s = do_sync(conn, dir, &scope, name)?;
+        // Restrict each source to the project dirs that physically live under it,
+        // so a project-scoped sync tags files with their own source (not whichever
+        // source's pass ran first). See sync_scope_projects_attributes_per_source.
+        let per_source_scope = match &scope {
+            SyncScope::All => SyncScope::All,
+            SyncScope::Projects(dirs) => SyncScope::Projects(
+                dirs.iter().filter(|d| d.starts_with(dir)).cloned().collect()
+            ),
+            SyncScope::File(f) => {
+                if f.starts_with(dir) {
+                    SyncScope::File(f.clone())
+                } else {
+                    // This source owns none of the requested file.
+                    SyncScope::Projects(Vec::new())
+                }
+            }
+        };
+        let s = do_sync(conn, dir, &per_source_scope, name)?;
         agg.added += s.added;
         agg.removed += s.removed;
         agg.changed += s.changed;
@@ -429,6 +446,42 @@ mod tests {
             .unwrap();
         assert_eq!(n_pinwheel, 1);
         assert_eq!(n_main, 1);
+    }
+
+    #[test]
+    fn sync_scope_projects_attributes_per_source() {
+        // Two sources each have a project dir of the SAME encoded name. Under a
+        // Projects scope that unions both dirs (as project_dirs_for_query would),
+        // each file must be tagged with its OWN source, not whichever ran first.
+        use crate::cache;
+        let cache_tmp = TempDir::new().unwrap();
+        let conn = cache::open(cache_tmp.path(), true).unwrap();
+
+        let main_tmp = TempDir::new().unwrap();
+        let env_tmp = TempDir::new().unwrap();
+        let main_proj = main_tmp.path().join("-Users-josh-shared");
+        let env_proj = env_tmp.path().join("-Users-josh-shared");
+        std::fs::create_dir_all(&main_proj).unwrap();
+        std::fs::create_dir_all(&env_proj).unwrap();
+        std::fs::write(main_proj.join("s1.jsonl"), "{\"cwd\":\"/x\"}\n").unwrap();
+        std::fs::write(env_proj.join("s2.jsonl"), "{\"cwd\":\"/x\"}\n").unwrap();
+
+        let sources = vec![
+            ("main".to_string(), main_tmp.path().to_path_buf()),
+            ("pinwheel".to_string(), env_tmp.path().to_path_buf()),
+        ];
+        // Union of both project dirs, the shape project_dirs_for_query produces.
+        let scope = SyncScope::Projects(vec![main_proj.clone(), env_proj.clone()]);
+        sync_sources(&conn, &sources, SyncMode::Force, scope, cache_tmp.path()).unwrap();
+
+        let n_main: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_registry WHERE source = 'main'", [], |r| r.get(0))
+            .unwrap();
+        let n_pinwheel: i64 = conn
+            .query_row("SELECT COUNT(*) FROM file_registry WHERE source = 'pinwheel'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n_main, 1, "main's file must be tagged 'main', not the other source");
+        assert_eq!(n_pinwheel, 1, "pinwheel's file must be tagged 'pinwheel', not 'main'");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod db;
 pub mod output;
 pub mod style;
 pub mod commands;
+pub mod source;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,10 @@ struct Cli {
     #[arg(long, global = true)]
     all: bool,
 
+    /// Scope to a named source (e.g. 'main', or a cenv env name). Spans all sources with --all.
+    #[arg(long, global = true)]
+    source: Option<String>,
+
     /// Maximum number of results (0 for unlimited)
     #[arg(long, global = true, default_value_t = 50)]
     limit: usize,
@@ -228,7 +232,32 @@ fn main() -> Result<()> {
         }
     }
 
-    let scope = QueryScope::new(project, cli.session, cli.since);
+    // Source scope: explicit --source wins; else auto-scope to the active source
+    // (the one matching CLAUDE_CONFIG_DIR), unless --all/--json/projects.
+    let (source, source_auto) = if cli.source.is_some() {
+        (cli.source.clone(), false)
+    } else if cli.all || cli.json || is_projects_cmd {
+        (None, false)
+    } else {
+        let active = std::env::var("CLAUDE_CONFIG_DIR")
+            .ok()
+            .and_then(|d| provider.source_for_config_dir(std::path::Path::new(&d)))
+            .unwrap_or_else(|| "main".to_string());
+        (Some(active), true)
+    };
+    if source_auto && !cli.json {
+        if let Some(ref s) = source {
+            let others = provider.sources().len().saturating_sub(1);
+            eprintln!(
+                "{}",
+                cq::style::hint(&format!(
+                    "Scoped to source '{s}' ({others} other sources; --all to span, --source <name> to target)"
+                ))
+            );
+        }
+    }
+
+    let scope = QueryScope::new(project, cli.session, cli.since).with_source(source);
 
     let sync_mode = if cli.reindex {
         db::SyncMode::Force
@@ -242,6 +271,12 @@ fn main() -> Result<()> {
         sync_mode,
         ..Default::default()
     };
+
+    let sources: Vec<(String, std::path::PathBuf)> = provider
+        .sources()
+        .iter()
+        .map(|s| (s.name.clone(), s.projects_dir.clone()))
+        .collect();
 
     let sync_scope = if cli.reindex {
         cq::sync_scope::SyncScope::All
@@ -257,7 +292,7 @@ fn main() -> Result<()> {
     };
 
     let start = std::time::Instant::now();
-    let db_setup = db::setup_connection(provider.base_dir(), &options, sync_scope)?;
+    let db_setup = db::setup_connection(&sources, &options, sync_scope)?;
     let elapsed = start.elapsed();
     if db_setup.lock_busy {
         eprintln!("index busy, using cached data (re-run with --reindex to force)");

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -28,11 +28,18 @@ pub struct QueryScope {
     pub project: Option<String>,
     pub session: Option<String>,
     pub since: Option<String>,
+    pub source: Option<String>,
 }
 
 impl QueryScope {
     pub fn new(project: Option<String>, session: Option<String>, since: Option<String>) -> Self {
-        Self { project, session, since }
+        Self { project, session, since, source: None }
+    }
+
+    /// Set the source filter (builder style so existing `new` callers are untouched).
+    pub fn with_source(mut self, source: Option<String>) -> Self {
+        self.source = source;
+        self
     }
 
     /// Parse --since into an absolute timestamp cutoff.

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,86 @@
+use std::path::{Path, PathBuf};
+
+/// A named transcript root that cq indexes. `name` is how the user refers to it
+/// (`main`, `pinwheel`, ...); `projects_dir` is the directory containing the
+/// encoded per-project session dirs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Source {
+    pub name: String,
+    pub projects_dir: PathBuf,
+}
+
+/// The default "main" source: `CQ_PROJECTS_DIR` if set, else `~/.claude/projects`.
+pub fn main_source() -> anyhow::Result<Source> {
+    use anyhow::Context;
+    let dir = if let Ok(dir) = std::env::var("CQ_PROJECTS_DIR") {
+        PathBuf::from(dir)
+    } else {
+        let home = dirs::home_dir().context("Could not determine home directory")?;
+        home.join(".claude").join("projects")
+    };
+    Ok(Source { name: "main".to_string(), projects_dir: dir })
+}
+
+/// cenv sources: one per `<cenv base>/<name>/projects` that exists on disk.
+/// Base is `$CENV_BASE` if set, else `~/.local/share/cenv`. Returns empty when
+/// the base does not exist. Sorted by name for deterministic ordering.
+pub fn discover_cenv_sources() -> Vec<Source> {
+    let base = match std::env::var("CENV_BASE") {
+        Ok(b) => PathBuf::from(b),
+        Err(_) => match dirs::home_dir() {
+            Some(h) => h.join(".local").join("share").join("cenv"),
+            None => return Vec::new(),
+        },
+    };
+    discover_cenv_sources_in(&base)
+}
+
+/// Testable core: scan `base/*/projects`. Only descends one level (the env dir),
+/// never into the env's `plugins/` cache.
+pub fn discover_cenv_sources_in(base: &Path) -> Vec<Source> {
+    let mut sources = Vec::new();
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return sources;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let projects_dir = entry.path().join("projects");
+        if projects_dir.is_dir() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            sources.push(Source { name, projects_dir });
+        }
+    }
+    sources.sort_by(|a, b| a.name.cmp(&b.name));
+    sources
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discovers_only_envs_with_projects_dir() {
+        let base = TempDir::new().unwrap();
+        // env "alpha" has a projects/ dir
+        fs::create_dir_all(base.path().join("alpha").join("projects")).unwrap();
+        // env "beta" has only a plugins cache, no projects/
+        fs::create_dir_all(base.path().join("beta").join("plugins")).unwrap();
+        // a stray file at the base is ignored
+        fs::write(base.path().join("notadir"), "x").unwrap();
+
+        let sources = discover_cenv_sources_in(base.path());
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].name, "alpha");
+        assert!(sources[0].projects_dir.ends_with("alpha/projects"));
+    }
+
+    #[test]
+    fn missing_base_returns_empty() {
+        let sources = discover_cenv_sources_in(Path::new("/no/such/cenv/base"));
+        assert!(sources.is_empty());
+    }
+}

--- a/src/views.rs
+++ b/src/views.rs
@@ -27,6 +27,10 @@ const WORKFLOW_ID_EXPR: &str =
 const AGENT_TYPE_EXPR: &str =
     "(SELECT fr.agent_type FROM file_registry fr WHERE fr.file_path = source_file)";
 
+/// SQL expression for the source name, read from file_registry at index time.
+const SOURCE_EXPR: &str =
+    "(SELECT fr.source FROM file_registry fr WHERE fr.file_path = source_file)";
+
 /// Register all queryable views against the given JSONL transcript files.
 ///
 /// Creates four views:
@@ -99,6 +103,7 @@ fn register_messages_view(conn: &Connection) -> Result<()> {
             SELECT
                 json_extract_string(json, '$.sessionId') AS session_id,
                 {PROJECT_EXPR} AS project,
+                {SOURCE_EXPR} AS source,
                 json_extract_string(json, '$.uuid') AS uuid,
                 json_extract_string(json, '$.parentUuid') AS parent_uuid,
                 json_extract_string(json, '$.type') AS type,
@@ -118,6 +123,7 @@ fn register_messages_view(conn: &Connection) -> Result<()> {
             SELECT
                 json_extract_string(json, '$.sessionId') AS session_id,
                 {PROJECT_EXPR} AS project,
+                {SOURCE_EXPR} AS source,
                 json_extract_string(json, '$.uuid') AS uuid,
                 json_extract_string(json, '$.parentUuid') AS parent_uuid,
                 json_extract_string(json, '$.type') AS type,
@@ -158,6 +164,7 @@ fn register_tool_calls_view(conn: &Connection) -> Result<()> {
         SELECT
             json_extract_string(json, '$.sessionId') AS session_id,
             {PROJECT_EXPR} AS project,
+            {SOURCE_EXPR} AS source,
             json_extract_string(json, '$.uuid') AS message_uuid,
             json_extract_string(item, '$.id') AS tool_use_id,
             json_extract_string(item, '$.name') AS name,
@@ -188,6 +195,7 @@ fn register_tool_results_view(conn: &Connection) -> Result<()> {
         SELECT
             json_extract_string(json, '$.sessionId') AS session_id,
             {PROJECT_EXPR} AS project,
+            {SOURCE_EXPR} AS source,
             json_extract_string(item, '$.tool_use_id') AS tool_use_id,
             COALESCE(CAST(json_extract(item, '$.is_error') AS BOOLEAN), false) AS is_error,
             json_extract_string(item, '$.content') AS content,
@@ -222,6 +230,10 @@ fn register_sessions_view(conn: &Connection) -> Result<()> {
                 MAX(project) FILTER (WHERE NOT is_sidechain),
                 MAX(project)
             ) AS project,
+            COALESCE(
+                MAX(source) FILTER (WHERE NOT is_sidechain),
+                MAX(source)
+            ) AS source,
             MIN(timestamp) FILTER (WHERE NOT is_sidechain) AS started_at,
             MAX(timestamp) FILTER (WHERE NOT is_sidechain) AS ended_at,
             COUNT(*) FILTER (WHERE NOT is_sidechain) AS message_count,
@@ -254,6 +266,7 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
         SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
             NULL::VARCHAR AS uuid,
             NULL::VARCHAR AS parent_uuid,
             NULL::VARCHAR AS type,
@@ -273,6 +286,7 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
         SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
             NULL::VARCHAR AS message_uuid,
             NULL::VARCHAR AS tool_use_id,
             NULL::VARCHAR AS name,
@@ -290,6 +304,7 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
         SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
             NULL::VARCHAR AS tool_use_id,
             false AS is_error,
             NULL::VARCHAR AS content,
@@ -305,6 +320,7 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
         SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
             NULL::VARCHAR AS started_at,
             NULL::VARCHAR AS ended_at,
             CAST(0 AS BIGINT) AS message_count,

--- a/tests/cache_test.rs
+++ b/tests/cache_test.rs
@@ -30,7 +30,7 @@ fn index_new_files() {
     let projects = setup_projects(&["simple_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    let result = cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    let result = cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
     assert_eq!(result.stats.added, 1);
     assert_eq!(result.stats.removed, 0);
     assert_eq!(result.stats.changed, 0);
@@ -52,8 +52,8 @@ fn no_changes_is_noop() {
     let projects = setup_projects(&["simple_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
-    let result = cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    let result = cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
     assert_eq!(result.stats.added, 0);
     assert_eq!(result.stats.removed, 0);
     assert_eq!(result.stats.changed, 0);
@@ -65,12 +65,12 @@ fn detects_deleted_files() {
     let projects = setup_projects(&["simple_session.jsonl", "error_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
 
     let project_dir = projects.path().join("-Users-test-myproject");
     std::fs::remove_file(project_dir.join("error_session.jsonl")).unwrap();
 
-    let result = cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    let result = cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
     assert_eq!(result.stats.removed, 1);
 
     let reg_count: i64 = conn
@@ -85,7 +85,7 @@ fn detects_changed_files() {
     let projects = setup_projects(&["simple_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
 
     let project_dir = projects.path().join("-Users-test-myproject");
     let file_path = project_dir.join("simple_session.jsonl");
@@ -93,7 +93,7 @@ fn detects_changed_files() {
     use std::io::Write;
     writeln!(f, "{{}}").unwrap();
 
-    let result = cq::indexer::sync(&conn, projects.path(), cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
+    let result = cq::indexer::sync_sources(&conn, &[("main".to_string(), projects.path().to_path_buf())], cq::db::SyncMode::Force, cq::sync_scope::SyncScope::All, cache.path()).unwrap();
     assert_eq!(result.stats.changed, 1);
 }
 
@@ -166,9 +166,10 @@ fn auto_sync_skips_when_nothing_changed() {
     let projects = setup_projects(&["simple_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    let result = cq::indexer::sync(
+    let sources = vec![("main".to_string(), projects.path().to_path_buf())];
+    let result = cq::indexer::sync_sources(
         &conn,
-        projects.path(),
+        &sources,
         cq::db::SyncMode::Auto,
         cq::sync_scope::SyncScope::All,
         cache.path(),
@@ -176,9 +177,9 @@ fn auto_sync_skips_when_nothing_changed() {
     assert_eq!(result.stats.added, 1);
     assert!(!result.skipped);
 
-    let result = cq::indexer::sync(
+    let result = cq::indexer::sync_sources(
         &conn,
-        projects.path(),
+        &sources,
         cq::db::SyncMode::Auto,
         cq::sync_scope::SyncScope::All,
         cache.path(),
@@ -194,17 +195,18 @@ fn force_sync_always_scans() {
     let projects = setup_projects(&["simple_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    cq::indexer::sync(
+    let sources = vec![("main".to_string(), projects.path().to_path_buf())];
+    cq::indexer::sync_sources(
         &conn,
-        projects.path(),
+        &sources,
         cq::db::SyncMode::Force,
         cq::sync_scope::SyncScope::All,
         cache.path(),
     ).unwrap();
 
-    let result = cq::indexer::sync(
+    let result = cq::indexer::sync_sources(
         &conn,
-        projects.path(),
+        &sources,
         cq::db::SyncMode::Force,
         cq::sync_scope::SyncScope::All,
         cache.path(),
@@ -218,9 +220,10 @@ fn skip_sync_returns_immediately() {
     let projects = setup_projects(&["simple_session.jsonl"]);
     let conn = cq::cache::open(cache.path(), false).unwrap();
 
-    let result = cq::indexer::sync(
+    let sources = vec![("main".to_string(), projects.path().to_path_buf())];
+    let result = cq::indexer::sync_sources(
         &conn,
-        projects.path(),
+        &sources,
         cq::db::SyncMode::Skip,
         cq::sync_scope::SyncScope::All,
         cache.path(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1501,3 +1501,231 @@ fn agent_type_null_for_main_loop() {
         .success()
         .stdout(predicate::str::contains("1"));
 }
+
+// ---- multi-source output (Task 9: source column + per-source grouping/skills) ----
+
+/// Build an env with a main source (CQ_PROJECTS_DIR) plus one cenv source
+/// (CENV_BASE/<env_name>/projects). Both carry the SAME project path so we can
+/// prove grouping by (source, project) and per-source skill correctness.
+///
+/// `main_jsonl` and `cenv_jsonl` are raw JSONL bodies written into a project dir
+/// named to match their embedded cwd ("/Users/test/myproject").
+struct MultiSourceEnv {
+    projects: TempDir,
+    cenv_base: TempDir,
+    cache: TempDir,
+    env_name: String,
+}
+
+fn setup_multi_source(env_name: &str, main_jsonl: &str, cenv_jsonl: &str) -> MultiSourceEnv {
+    let projects = TempDir::new().unwrap();
+    let cenv_base = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    // main source: CQ_PROJECTS_DIR/-Users-test-myproject/
+    let main_proj = projects.path().join("-Users-test-myproject");
+    std::fs::create_dir_all(&main_proj).unwrap();
+    std::fs::write(main_proj.join("main-sess.jsonl"), main_jsonl).unwrap();
+
+    // cenv source: CENV_BASE/<env_name>/projects/-Users-test-myproject/
+    let cenv_proj = cenv_base
+        .path()
+        .join(env_name)
+        .join("projects")
+        .join("-Users-test-myproject");
+    std::fs::create_dir_all(&cenv_proj).unwrap();
+    std::fs::write(cenv_proj.join("cenv-sess.jsonl"), cenv_jsonl).unwrap();
+
+    MultiSourceEnv {
+        projects,
+        cenv_base,
+        cache,
+        env_name: env_name.to_string(),
+    }
+}
+
+fn multi_cmd(env: &MultiSourceEnv) -> Command {
+    let mut cmd = Command::cargo_bin("cq").unwrap();
+    cmd.env("CQ_PROJECTS_DIR", env.projects.path());
+    cmd.env("CQ_CACHE_DIR", env.cache.path());
+    cmd.env("CENV_BASE", env.cenv_base.path());
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+// A user+assistant pair in /Users/test/myproject with one Skill call.
+// Caller supplies a distinct sessionId and skill name.
+fn session_with_skill(session_id: &str, skill: &str, tool_id: &str) -> String {
+    format!(
+        "{{\"type\":\"user\",\"message\":{{\"role\":\"user\",\"content\":\"do a thing\"}},\"uuid\":\"u-{session_id}\",\"parentUuid\":null,\"isSidechain\":false,\"timestamp\":\"2026-04-13T10:00:00.000Z\",\"sessionId\":\"{session_id}\",\"cwd\":\"/Users/test/myproject\"}}\n\
+         {{\"type\":\"assistant\",\"message\":{{\"id\":\"m-{session_id}\",\"role\":\"assistant\",\"model\":\"claude-opus-4-6\",\"content\":[{{\"type\":\"tool_use\",\"id\":\"{tool_id}\",\"name\":\"Skill\",\"input\":{{\"skill\":\"{skill}\"}}}}]}},\"uuid\":\"a-{session_id}\",\"parentUuid\":\"u-{session_id}\",\"isSidechain\":false,\"timestamp\":\"2026-04-13T10:00:05.000Z\",\"sessionId\":\"{session_id}\",\"cwd\":\"/Users/test/myproject\"}}\n"
+    )
+}
+
+#[test]
+fn projects_unscoped_groups_by_source() {
+    // Same project path under two sources -> two rows when unscoped (--all).
+    let main_body = session_with_skill("11111111-1111-1111-1111-111111111111", "sanitation", "toolu_m1");
+    let cenv_body = session_with_skill("22222222-2222-2222-2222-222222222222", "obsidian", "toolu_c1");
+    let env = setup_multi_source("pinwheel", &main_body, &cenv_body);
+
+    let output = multi_cmd(&env)
+        .args(["--json", "--all", "projects"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+
+    // myproject appears under both 'main' and 'pinwheel': two rows.
+    let myproject_rows: Vec<&serde_json::Value> = parsed
+        .iter()
+        .filter(|r| r["project"].as_str() == Some("/Users/test/myproject"))
+        .collect();
+    assert_eq!(
+        myproject_rows.len(),
+        2,
+        "same project path under two sources should produce two rows, got: {stdout}"
+    );
+    let sources: std::collections::HashSet<&str> = myproject_rows
+        .iter()
+        .filter_map(|r| r["source"].as_str())
+        .collect();
+    assert!(sources.contains("main"), "expected a 'main' source row, got: {sources:?}");
+    assert!(sources.contains("pinwheel"), "expected a 'pinwheel' source row, got: {sources:?}");
+}
+
+#[test]
+fn projects_scoped_groups_by_project_only() {
+    // Scoped to one source -> a single row for the project (no per-source split).
+    let main_body = session_with_skill("11111111-1111-1111-1111-111111111111", "sanitation", "toolu_m1");
+    let cenv_body = session_with_skill("22222222-2222-2222-2222-222222222222", "obsidian", "toolu_c1");
+    let env = setup_multi_source("pinwheel", &main_body, &cenv_body);
+
+    let output = multi_cmd(&env)
+        .args(["--json", "--source", "main", "projects"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+
+    let myproject_rows: Vec<&serde_json::Value> = parsed
+        .iter()
+        .filter(|r| r["project"].as_str() == Some("/Users/test/myproject"))
+        .collect();
+    assert_eq!(
+        myproject_rows.len(),
+        1,
+        "scoped to one source the project should be a single row, got: {stdout}"
+    );
+    assert_eq!(myproject_rows[0]["source"].as_str(), Some("main"));
+}
+
+#[test]
+fn projects_skill_count_is_per_source() {
+    // Each source has a distinct Skill call for the same project path.
+    // --source main must reflect only main's skill, not the cenv source's.
+    let main_body = session_with_skill("11111111-1111-1111-1111-111111111111", "sanitation", "toolu_m1");
+    let cenv_body = session_with_skill("22222222-2222-2222-2222-222222222222", "obsidian", "toolu_c1");
+    let env = setup_multi_source("pinwheel", &main_body, &cenv_body);
+
+    // Scoped to main: skills = ["sanitation"], count 1 (NOT 2, which would mean
+    // it counted the cenv source's skill too).
+    let output = multi_cmd(&env)
+        .args(["--json", "--source", "main", "projects"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+    let row = parsed
+        .iter()
+        .find(|r| r["project"].as_str() == Some("/Users/test/myproject"))
+        .expect("myproject row");
+    assert_eq!(row["skill_count"].as_i64(), Some(1), "main should count only its own skill, got: {stdout}");
+    let skills: Vec<&str> = row["skills"].as_array().unwrap().iter().filter_map(|s| s.as_str()).collect();
+    assert_eq!(skills, vec!["sanitation"], "main should list only its own skill, got: {skills:?}");
+
+    // Scoped to the cenv source: skills = ["obsidian"].
+    let output = multi_cmd(&env)
+        .args(["--json", "--source", &env.env_name, "projects"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+    let row = parsed
+        .iter()
+        .find(|r| r["project"].as_str() == Some("/Users/test/myproject"))
+        .expect("myproject row");
+    let skills: Vec<&str> = row["skills"].as_array().unwrap().iter().filter_map(|s| s.as_str()).collect();
+    assert_eq!(skills, vec!["obsidian"], "cenv source should list only its own skill, got: {skills:?}");
+}
+
+#[test]
+fn projects_display_skill_count_per_source() {
+    // Default (non-JSON) display: per-source skill counts must not bleed across
+    // sources. Each source has exactly one distinct skill for the same project.
+    let main_body = session_with_skill("11111111-1111-1111-1111-111111111111", "sanitation", "toolu_m1");
+    let cenv_body = session_with_skill("22222222-2222-2222-2222-222222222222", "obsidian", "toolu_c1");
+    let env = setup_multi_source("pinwheel", &main_body, &cenv_body);
+
+    let output = multi_cmd(&env)
+        .args(["--source", "main", "projects", "--skills"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // main's skill appears; the cenv source's skill must NOT.
+    assert!(stdout.contains("sanitation"), "main's skill should show, got: {stdout}");
+    assert!(!stdout.contains("obsidian"), "cenv source's skill must not leak into main, got: {stdout}");
+    assert!(stdout.contains("1 skills"), "main should count exactly 1 skill, got: {stdout}");
+}
+
+#[test]
+fn sessions_source_column_by_flag() {
+    let main_body = session_with_skill("11111111-1111-1111-1111-111111111111", "sanitation", "toolu_m1");
+    let cenv_body = session_with_skill("22222222-2222-2222-2222-222222222222", "obsidian", "toolu_c1");
+    let env = setup_multi_source("pinwheel", &main_body, &cenv_body);
+
+    // --all (unscoped): SOURCE column present in table output.
+    let output = multi_cmd(&env)
+        .args(["--table", "--all", "sessions"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("source"), "SOURCE column should appear under --all, got: {stdout}");
+    assert!(stdout.contains("main"), "main source value should appear, got: {stdout}");
+    assert!(stdout.contains("pinwheel"), "pinwheel source value should appear, got: {stdout}");
+
+    // --source main: SOURCE column omitted (redundant).
+    let output = multi_cmd(&env)
+        .args(["--table", "--source", "main", "sessions"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Header row is the column names; "source" must not be a header.
+    let header_line = stdout.lines().find(|l| l.contains("project") && l.contains("session")).unwrap_or("");
+    assert!(!header_line.contains("source"), "SOURCE column should be omitted when scoped, header: {header_line}");
+}
+
+#[test]
+fn sessions_json_always_includes_source() {
+    let main_body = session_with_skill("11111111-1111-1111-1111-111111111111", "sanitation", "toolu_m1");
+    let cenv_body = session_with_skill("22222222-2222-2222-2222-222222222222", "obsidian", "toolu_c1");
+    let env = setup_multi_source("pinwheel", &main_body, &cenv_body);
+
+    // Even scoped to one source, JSON carries the source field.
+    let output = multi_cmd(&env)
+        .args(["--json", "--source", "main", "sessions"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
+    assert!(!parsed.is_empty(), "expected at least one session, got: {stdout}");
+    assert_eq!(parsed[0]["source"].as_str(), Some("main"), "JSON should carry source, got: {stdout}");
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31,6 +31,8 @@ fn cq_cmd(env: &TestEnv) -> Command {
     let mut cmd = Command::cargo_bin("cq").unwrap();
     cmd.env("CQ_PROJECTS_DIR", env.projects.path());
     cmd.env("CQ_CACHE_DIR", env.cache.path());
+    // Isolate from any real cenv envs on the host so only CQ_PROJECTS_DIR is indexed.
+    cmd.env("CENV_BASE", env.cache.path().join("no-such-cenv-base"));
     cmd.env("NO_COLOR", "1");
     cmd
 }
@@ -273,6 +275,7 @@ fn no_color_flag() {
     let mut cmd = Command::cargo_bin("cq").unwrap();
     cmd.env("CQ_PROJECTS_DIR", env.projects.path());
     cmd.env("CQ_CACHE_DIR", env.cache.path());
+    cmd.env("CENV_BASE", env.cache.path().join("no-such-cenv-base"));
     // Explicitly unset NO_COLOR so we're testing the flag, not the env var
     cmd.env_remove("NO_COLOR");
 

--- a/tests/views_test.rs
+++ b/tests/views_test.rs
@@ -622,6 +622,86 @@ fn sessions_filter_by_source() {
     assert_eq!(main_n, 1, "the other source is excluded by the filter");
 }
 
+// ---- tool_calls source filtering (summary mode) ----
+
+#[test]
+fn tool_calls_filter_by_source() {
+    use std::path::PathBuf;
+    let conn = duckdb::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE file_registry (
+            file_path TEXT PRIMARY KEY,
+            mtime_ns BIGINT,
+            file_size BIGINT,
+            cwd TEXT,
+            agent_type TEXT,
+            source TEXT,
+            indexed_at TIMESTAMP DEFAULT current_timestamp
+        )",
+    )
+    .unwrap();
+
+    // simple_session.jsonl has 1 tool call; multi_tool_session.jsonl has 4.
+    // Tag them with different sources to verify source filtering on tool_calls.
+    let main_path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("simple_session.jsonl");
+    let pinwheel_path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("multi_tool_session.jsonl");
+
+    conn.execute(
+        "INSERT INTO file_registry (file_path, mtime_ns, file_size, cwd, agent_type, source)
+         VALUES (?, 0, 0, '/Users/test/myproject', NULL, 'main')",
+        [&main_path.display().to_string()],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO file_registry (file_path, mtime_ns, file_size, cwd, agent_type, source)
+         VALUES (?, 0, 0, '/Users/test/pinwheel', NULL, 'pinwheel')",
+        [&pinwheel_path.display().to_string()],
+    )
+    .unwrap();
+
+    cq::views::register_views(&conn, &[main_path, pinwheel_path]).unwrap();
+
+    // Baseline: all tool calls present across both sources.
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM tool_calls", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total, 5, "1 from simple_session + 4 from multi_tool_session");
+
+    // Source filter restricts to pinwheel's 4 tool calls.
+    let pinwheel_n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM tool_calls WHERE source = ?",
+            duckdb::params!["pinwheel"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(pinwheel_n, 4, "source='pinwheel' returns only pinwheel tool calls");
+
+    // Source filter restricts to main's 1 tool call.
+    let main_n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM tool_calls WHERE source = ?",
+            duckdb::params!["main"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(main_n, 1, "source='main' returns only main tool calls");
+
+    // Nonexistent source returns 0 (matches run_summary behavior with --source nonexistent).
+    let none_n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM tool_calls WHERE source = ?",
+            duckdb::params!["nonexistent"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(none_n, 0, "nonexistent source returns no tool calls");
+}
+
 // ---- empty files ----
 
 #[test]

--- a/tests/views_test.rs
+++ b/tests/views_test.rs
@@ -19,6 +19,7 @@ fn setup_db(fixture: &str) -> Connection {
             file_size BIGINT,
             cwd TEXT,
             agent_type TEXT,
+            source TEXT,
             indexed_at TIMESTAMP DEFAULT current_timestamp
         )"
     ).unwrap();
@@ -38,6 +39,7 @@ fn setup_db_multi(fixtures: &[&str]) -> Connection {
             file_size BIGINT,
             cwd TEXT,
             agent_type TEXT,
+            source TEXT,
             indexed_at TIMESTAMP DEFAULT current_timestamp
         )"
     ).unwrap();
@@ -461,6 +463,7 @@ fn agent_type_flows_from_registry() {
             file_size BIGINT,
             cwd TEXT,
             agent_type TEXT,
+            source TEXT,
             indexed_at TIMESTAMP DEFAULT current_timestamp
         )",
     )
@@ -504,6 +507,7 @@ fn sessions_single_row_across_cwds() {
             file_size BIGINT,
             cwd TEXT,
             agent_type TEXT,
+            source TEXT,
             indexed_at TIMESTAMP DEFAULT current_timestamp
         )",
     )

--- a/tests/views_test.rs
+++ b/tests/views_test.rs
@@ -556,6 +556,72 @@ fn sessions_single_row_across_cwds() {
     assert_eq!(subs, 1, "the other-cwd subagent is still counted");
 }
 
+#[test]
+fn sessions_filter_by_source() {
+    use std::path::PathBuf;
+    let conn = duckdb::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE file_registry (
+            file_path TEXT PRIMARY KEY,
+            mtime_ns BIGINT,
+            file_size BIGINT,
+            cwd TEXT,
+            agent_type TEXT,
+            source TEXT,
+            indexed_at TIMESTAMP DEFAULT current_timestamp
+        )",
+    )
+    .unwrap();
+
+    // Two distinct sessions, each tagged with a different source.
+    let main_path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("simple_session.jsonl");
+    let pinwheel_path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join("multi_tool_session.jsonl");
+
+    conn.execute(
+        "INSERT INTO file_registry (file_path, mtime_ns, file_size, cwd, agent_type, source)
+         VALUES (?, 0, 0, '/Users/test/myproject', NULL, 'main')",
+        [&main_path.display().to_string()],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO file_registry (file_path, mtime_ns, file_size, cwd, agent_type, source)
+         VALUES (?, 0, 0, '/Users/test/pinwheel', NULL, 'pinwheel')",
+        [&pinwheel_path.display().to_string()],
+    )
+    .unwrap();
+
+    cq::views::register_views(&conn, &[main_path, pinwheel_path]).unwrap();
+
+    // Both sources are present across all sessions.
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(total, 2, "both sessions are indexed");
+
+    // The source = ? predicate (as built by the command scope WHERE sites) restricts to one.
+    let n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE source = ?",
+            duckdb::params!["pinwheel"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(n, 1, "source filter restricts sessions to the matching source");
+
+    let main_n: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE source = ?",
+            duckdb::params!["main"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(main_n, 1, "the other source is excluded by the filter");
+}
+
 // ---- empty files ----
 
 #[test]


### PR DESCRIPTION
## Summary

- cq now indexes sessions from every cenv environment (`$CENV_BASE/*/projects`), not just `~/.claude/projects`. Sessions that lived in an isolated env used to be invisible to cq; now they're queryable.
- Every row carries a `source` (the env name, or `main`), and cq auto-scopes to whichever source you're working in (the one matching `$CLAUDE_CONFIG_DIR`, else `main`), mirroring how it already auto-scopes to the current directory. `--all` spans every source, `--source <name>` targets one, both compose with `--since`. `cq projects` groups by `(source, project)` and skill counts are per-source.
- Sources are found by directory convention; cq never shells out to cenv. Config-listed sources and per-source metadata are left as wired-in extension points for later.

## Test plan

- `cargo test` (full suite green)
- `cq --all sessions` shows a SOURCE column; `cq --source main sessions` omits it; `cq --all projects` groups by source; `cq schema sessions` lists the `source` column

## Notes

- The branch is a couple commits behind `main` (the recent `--since`/`cq sql` skill fix and its plugin bump); it merges cleanly since those touch different regions.
- I did not bump the claude-plugin `plugin.json` version, no per-feature convention I'm aware of. Bump it to taste if cq versions per feature.
