### PR TITLE
Prototype an opencode session source (SQLite via DuckDB ATTACH)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ chrono = "0.4"
 anyhow = "1"
 dirs = "5"
 
+[[example]]
+name = "opencode_spike"
+path = "examples/opencode_spike.rs"
+
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"

--- a/docs/opencode-source-findings.md
+++ b/docs/opencode-source-findings.md
@@ -1,0 +1,248 @@
+# opencode Source: Findings & Design Input
+
+This document captures the schema mapping, integration analysis, and open design
+questions for wiring opencode session data into cq's existing views.
+
+## Status
+
+Prototype complete. SQL queries validated against a live
+`~/.local/share/opencode/opencode.db` (v1.17.5 format). Rust code artifacts
+in `examples/opencode_spike.rs` and `tests/opencode_spike.rs` compile but
+require ~3GB free disk to build from source.
+
+## Schema mapping
+
+### sessions view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `session.id` | Different namespace (`ses_...` prefix) |
+| `project` | `session.directory` | Real path; no encoding/decoding needed |
+| `source` | constant `'opencode'` | |
+| `started_at` | `session.time_created` (epoch ms) | Needs `/1000` and ISO 8601 format conversion |
+| `ended_at` | `session.time_updated` (epoch ms) | Same conversion |
+| `message_count` | COUNT from `message` table | |
+| `tool_call_count` | COUNT of `part` rows with `data.type='tool'` | |
+| `user_message_count` | COUNT of `message` rows with `data.role='user'` | |
+| `subagent_count` | COUNT of `session` rows with `parent_id = s.id` | Different model: sub-agents are sessions not in-message |
+| `first_user_message` | `session.title` | opencode sets title to the initial prompt |
+
+Missing from opencode: nothing critical absent; `session.model` (JSON) is extra data available.
+
+### messages view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `message.session_id` | |
+| `project` | via `session.directory` JOIN | |
+| `source` | constant `'opencode'` | |
+| `uuid` | `message.id` | Different namespace (`msg_...` prefix) |
+| `parent_uuid` | `json_extract(message.data, '$.parentID')` | |
+| `type` | `json_extract(message.data, '$.role')` | Values: `user`, `assistant` |
+| `timestamp` | `message.time_created` (epoch ms) | ISO 8601 conversion needed |
+| `text` | `part.data.text` where `part.data.type='text'` | Text NOT in message.data; lives in part table |
+| `tool_count` | COUNT of `part` rows with `data.type='tool'` for this message | |
+| `model` | `message.data.modelID` (assistant) OR `message.data.model.modelID` (user) | Different path by role |
+| `agent_id` | NULL | Sub-agents are sessions, not in-message IDs |
+| `is_sidechain` | false | Main loop only; sub-sessions handled via parent_id |
+| `agent_type` | `json_extract(message.data, '$.agent')` | Values: `build`, `general`, etc. |
+| `workflow_id` | NULL | opencode has no workflow concept |
+
+Key gap: `text` for user messages comes from part rows (type='text'), not from the
+message's own data column. The initial user prompt text is in `session.title` instead.
+
+### tool_calls view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `part.session_id` | |
+| `project` | via `session.directory` JOIN | |
+| `source` | constant `'opencode'` | |
+| `message_uuid` | `part.message_id` | |
+| `tool_use_id` | `json_extract(part.data, '$.callID')` | String (opencode) vs string (cq); join key |
+| `name` | `json_extract(part.data, '$.tool')` | e.g. `bash`, `read`, `write`, `grep`, `task` |
+| `input` | `json_extract(part.data, '$.state.input')` | JSON object, maps cleanly |
+| `timestamp` | `part.time_created` (epoch ms) | |
+| `agent_id` | NULL | |
+| `is_sidechain` | false | |
+| `agent_type` | via `message.data.agent` JOIN | |
+| `workflow_id` | NULL | |
+
+### tool_results view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `part.session_id` | |
+| `project` | via `session.directory` JOIN | |
+| `source` | constant `'opencode'` | |
+| `tool_use_id` | `json_extract(part.data, '$.callID')` | Same part row as tool_calls |
+| `is_error` | `part.data.state.status != 'completed'` | 49 completed / 1 error in live data |
+| `content` | `json_extract(part.data, '$.state.output')` | The stdout/result text |
+| `agent_id` | NULL | |
+| `is_sidechain` | false | |
+| `agent_type` | via `message.data.agent` JOIN | |
+| `workflow_id` | NULL | |
+
+## Key structural difference: tool call/result co-location
+
+In cq/Claude Code, a tool call (the request) and tool result (the response) are
+separate JSONL records. They join on `tool_use_id`.
+
+In opencode, both live in the SAME `part` row: `state.input` is the call,
+`state.output` is the result. The `callID` field is the equivalent of `tool_use_id`.
+
+This means:
+- `tool_calls` and `tool_results` views over opencode produce the SAME row count.
+- The join key (`callID` = `tool_use_id`) works correctly.
+- No "pending tool call without result" rows exist in opencode (call and result are
+  atomic from the DB perspective).
+
+## Does the data map cleanly?
+
+Yes, with three predictable wrinkles:
+
+1. **Timestamp units.** opencode stores all times as epoch milliseconds (BIGINT).
+   cq stores timestamps as ISO 8601 VARCHAR strings. A native provider needs to emit
+   ISO 8601 from the SQL (DuckDB: `strftime(epoch_ms(t), format)`; SQLite:
+   `datetime(t/1000, 'unixepoch')`).
+
+2. **Text content is in parts, not messages.** The user message text field requires
+   a subquery against the `part` table. The initial user prompt is in `session.title`
+   rather than appearing as a separate text part (it's the session's title).
+
+3. **Sub-agents are sessions, not in-message IDs.** cq uses `agent_id` (an in-message
+   field) to identify sub-agent work; opencode creates a full child session with
+   `parent_id` pointing to the parent. Mapping: `agent_id = NULL` everywhere,
+   `subagent_count = COUNT(child sessions)`. The cq concepts `is_sidechain` and
+   `workflow_id` have no equivalent in opencode.
+
+No data is lost; the gaps (`agent_id`, `is_sidechain`, `workflow_id`) all NULL-out
+cleanly.
+
+## Timestamp conversion
+
+opencode: `time_created INTEGER` (epoch milliseconds, e.g. `1781732636455`)
+
+DuckDB conversion: `strftime(epoch_ms(time_created), '%Y-%m-%dT%H:%M:%SZ')`
+
+SQLite conversion (for testing): `datetime(time_created/1000, 'unixepoch')`
+
+cq currently stores timestamps as VARCHAR ISO 8601 strings. A native OpenCode
+provider would need to emit the same format for string comparisons in the sessions
+view (`MIN(timestamp)`, `MAX(timestamp)`) to work correctly.
+
+## Integration path analysis
+
+### Option (a): Converter materialization
+
+Convert opencode sessions to Claude Code-compatible JSONL in a temp directory, then
+let the existing `ClaudeProvider` index them.
+
+**What this costs:**
+- Write a one-shot converter (Rust or shell) that reads opencode.db and writes JSONL
+  files in the format `<projects_dir>/<encoded-project>/<session-id>.jsonl`.
+- The converter must translate each `(session, message, part)` triple into cq's
+  existing JSON envelope: `{ "type": "user"|"assistant", "uuid": "...", "sessionId":
+  "...", "timestamp": "...", "message": { "content": [...] } }`.
+- The directory layout must match what `ClaudeProvider` expects.
+- The converter output is ephemeral (temp dir) or persistent (synced dir).
+- No changes to cq's core codebase.
+
+**What it doesn't cost:**
+- No changes to `main.rs` provider dispatch.
+- No changes to `indexer.rs` or `views.rs`.
+- Can be implemented entirely outside the cq codebase.
+
+**Drawbacks:**
+- Data fidelity: some opencode fields (cost, token breakdown, diffs) are not in
+  cq's JSONL schema and would be dropped.
+- Staleness: the converter must be re-run when opencode adds sessions.
+- The produced JSONL is a translation artifact, not the real data.
+- Tool call/result co-location needs careful splitting into separate JSONL records.
+
+### Option (b): Native OpenCodeProvider
+
+A new `OpenCodeProvider` that implements `TranscriptProvider` and reads opencode.db
+directly, generating cq views that query the SQLite tables.
+
+**What this costs:**
+- A new provider struct in `src/opencode_provider.rs`.
+- `register_views()` must create SQL views reading from the attached SQLite DB
+  (DuckDB's `ATTACH ... (TYPE sqlite)` mechanism).
+- The `main.rs` dispatch refactor: today `ClaudeProvider` is constructed directly
+  (`~line 209`); the code does not use the `TranscriptProvider` trait polymorphically.
+  A second provider forces this refactor (likely `Box<dyn TranscriptProvider>`).
+- `indexer.rs` assumes `read_json` over JSONL files; the SQLite source breaks this
+  assumption. The indexer would need a bypass or a separate "sqlite source" code
+  path. The `file_registry` mtime/size model does not apply to a single DB file.
+- `cache.rs` schema (`file_registry`) stores per-file mtime/size. A SQLite source
+  would need a different freshness mechanism (e.g., check opencode.db mtime).
+- Views that reference `source_file` (currently all four cq views do) would need
+  alternatives for the non-JSONL case.
+
+**What it doesn't cost:**
+- No data fidelity loss; native SQL over the real tables.
+- No converter maintenance.
+- Automatically reflects new sessions.
+
+### Recommendation
+
+For the immediate spike/integration: **start with (a)**. The converter approach
+lets you validate the schema mapping with zero changes to the cq codebase. The
+JSONL output can be pointed at with `CQ_PROJECTS_DIR` in tests.
+
+For the production integration: **(b) is the right long-term answer**, but only
+after the `main.rs` polymorphic dispatch refactor is done as a separate PR. The
+refactor is ~50 lines of straightforward Rust but it touches the cq startup path
+and deserves its own review.
+
+The two paths are not mutually exclusive: ship (a) as the cq v1.x opencode bridge,
+then replace it with (b) in v2.
+
+## SQLite source and the mtime cache model
+
+cq's incremental cache uses `file_registry(file_path, mtime_ns, file_size)` to
+decide what to re-parse. A SQLite source breaks this in two ways:
+
+1. There's ONE file (`opencode.db`) not many JSONL files. The "file" is the whole DB.
+2. opencode.db is append-only; a change in mtime means "there's new data," not "this
+   whole file changed." The indexer would over-index (re-reading everything on any
+   DB change) unless it tracks some other cursor (e.g., `MAX(time_updated)` from
+   the session table, or the sqlite `wal` checkpoint sequence).
+
+The cleanest approach for (b): store the DB path in `file_registry` with the opencode.db
+mtime. When mtime changes, run a "delta scan" that queries `WHERE time_created > last_seen`.
+This needs a new column in `file_registry` (e.g., `cursor BIGINT`) to store the last
+`MAX(session.time_updated)` seen.
+
+Option (a) sidesteps this entirely: the converter controls the JSONL files, which
+have normal mtimes.
+
+## Open questions for the design step
+
+1. **Provider dispatch refactor scope.** How disruptive is the `main.rs` refactor
+   to go from `ClaudeProvider` directly to `Box<dyn TranscriptProvider>`? Are there
+   other callers that would also need updating?
+
+2. **Sub-agent representation.** opencode's parent_id sub-sessions vs cq's in-message
+   `agent_id`. For the production integration: should opencode sub-sessions be
+   surfaced as first-class sessions (with `is_sidechain = true` on the parent's
+   messages)? Or should they be flattened? The current prototype nulls both out.
+
+3. **Source column in the cache.** `file_registry.source` was added for the
+   multi-source PR. A SQLite source with no JSONL files needs a different key.
+   What's the canonical "file path" for an opencode source row?
+
+4. **Scope filtering.** `cq sessions --project .` scans the current directory
+   against `project` in the sessions view. For opencode, `project = session.directory`
+   (real path). The ILIKE match should work as-is. Verify this.
+
+5. **Token / cost data.** opencode tracks `cost`, `tokens_input/output/reasoning/
+   cache_read/cache_write` per session. cq currently has no cost/tokens in any view.
+   Worth adding to the sessions view in a future PR?
+
+6. **DuckDB sqlite extension bundling.** The prototype uses `INSTALL sqlite` which
+   downloads the extension from DuckDB's servers on first use. For a production
+   integration, we'd want this bundled or pre-installed. The `libduckdb-sys` crate
+   has a `duckdb-loadable-extension` feature but not a bundled sqlite scanner.
+   How does the extension get delivered?

--- a/examples/opencode_spike.rs
+++ b/examples/opencode_spike.rs
@@ -1,0 +1,292 @@
+//! Prototype: query opencode's SQLite DB via DuckDB and emit cq-shaped output.
+//!
+//! Run with:
+//!   cargo run --example opencode_spike
+//!   cargo run --example opencode_spike -- --messages
+//!   cargo run --example opencode_spike -- --tools
+//!
+//! Requires the DuckDB sqlite extension (downloaded on first run; needs network).
+//! The opencode DB at ~/.local/share/opencode/opencode.db is opened read-only.
+
+use anyhow::{Context, Result};
+use cq::output::{self, OutputFormat};
+use duckdb::Connection;
+use std::env;
+use std::path::PathBuf;
+
+fn opencode_db_path() -> PathBuf {
+    dirs::home_dir()
+        .expect("no home dir")
+        .join(".local/share/opencode/opencode.db")
+}
+
+fn setup(db_path: &PathBuf) -> Result<Connection> {
+    let conn = Connection::open_in_memory().context("open in-memory DuckDB")?;
+
+    // Install the SQLite scanner extension (downloads once to ~/.duckdb/extensions/).
+    // If this fails with a network error, set DUCKDB_EXTENSION_DIR or pre-download.
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")
+        .context("install/load sqlite extension")?;
+
+    // Attach the opencode DB read-only so we never accidentally write to it.
+    conn.execute_batch(&format!(
+        "ATTACH '{}' AS oc (TYPE sqlite, READ_ONLY);",
+        db_path.display()
+    ))
+    .context("attach opencode.db")?;
+
+    Ok(conn)
+}
+
+// --- view definitions ---
+
+/// cq sessions equivalent: one row per top-level opencode session.
+///
+/// Mapping notes vs cq's sessions view:
+/// - project  = session.directory (the worktree path)
+/// - started_at/ended_at: epoch_ms(bigint)::VARCHAR, format is "YYYY-MM-DD HH:MM:SS.mmm"
+///   (cq uses ISO 8601 "YYYY-MM-DDTHH:MM:SSZ"; real integration would normalize)
+/// - first_user_message = session.title (opencode sets this to the user's initial prompt)
+/// - subagent_count = child sessions (parent_id != NULL), not in-message agent_id
+///   (opencode's sub-agent model differs from CC: each sub-agent IS a session)
+fn create_oc_sessions_view(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_sessions AS
+        SELECT
+            s.id                                    AS session_id,
+            s.directory                             AS project,
+            'opencode'                              AS source,
+            epoch_ms(s.time_created)::VARCHAR       AS started_at,
+            epoch_ms(s.time_updated)::VARCHAR       AS ended_at,
+            (SELECT COUNT(*)
+             FROM oc.message m
+             WHERE m.session_id = s.id)             AS message_count,
+            (SELECT COUNT(*)
+             FROM oc.part p
+             WHERE p.session_id = s.id
+               AND json_extract_string(p.data, '$.type') = 'tool')
+                                                    AS tool_call_count,
+            (SELECT COUNT(*)
+             FROM oc.message m
+             WHERE m.session_id = s.id
+               AND json_extract_string(m.data, '$.role') = 'user')
+                                                    AS user_message_count,
+            (SELECT COUNT(*)
+             FROM oc.session sub
+             WHERE sub.parent_id = s.id)            AS subagent_count,
+            s.title                                 AS first_user_message
+        FROM oc.session s
+        WHERE s.parent_id IS NULL
+        ORDER BY s.time_created DESC",
+    )
+    .context("create oc_sessions view")?;
+    Ok(())
+}
+
+/// cq messages equivalent.
+///
+/// Mapping notes:
+/// - uuid/parent_uuid use opencode's message.id / data.parentID (different ID namespace)
+/// - type maps from data.role: 'user' or 'assistant'
+/// - text is extracted from parts with type='text' (not stored in message.data directly)
+/// - model: assistant messages store modelID at top level; user messages store it nested
+/// - is_sidechain: false for all rows here (sub-sessions are separate sessions in opencode)
+/// - agent_type: data.agent field ('build', 'general', etc.)
+fn create_oc_messages_view(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_messages AS
+        SELECT
+            m.session_id,
+            s.directory                                         AS project,
+            'opencode'                                          AS source,
+            m.id                                               AS uuid,
+            json_extract_string(m.data, '$.parentID')          AS parent_uuid,
+            json_extract_string(m.data, '$.role')              AS type,
+            epoch_ms(m.time_created)::VARCHAR                   AS timestamp,
+            (SELECT json_extract_string(p.data, '$.text')
+             FROM oc.part p
+             WHERE p.message_id = m.id
+               AND json_extract_string(p.data, '$.type') = 'text'
+             LIMIT 1)                                           AS text,
+            (SELECT COUNT(*)
+             FROM oc.part p
+             WHERE p.message_id = m.id
+               AND json_extract_string(p.data, '$.type') = 'tool')
+                                                                AS tool_count,
+            COALESCE(
+                json_extract_string(m.data, '$.modelID'),
+                json_extract_string(m.data, '$.model.modelID')
+            )                                                   AS model,
+            NULL::VARCHAR                                       AS agent_id,
+            false                                               AS is_sidechain,
+            json_extract_string(m.data, '$.agent')             AS agent_type,
+            NULL::VARCHAR                                       AS workflow_id
+        FROM oc.message m
+        JOIN oc.session s ON s.id = m.session_id
+        ORDER BY m.time_created",
+    )
+    .context("create oc_messages view")?;
+    Ok(())
+}
+
+/// cq tool_calls equivalent.
+///
+/// Mapping notes:
+/// - tool_use_id = part.data.callID (opencode's per-call identifier)
+/// - name = part.data.tool (e.g. 'bash', 'read', 'write', 'task')
+/// - input = part.data.state.input (JSON object)
+/// - IMPORTANT: in opencode, tool call + result live in the SAME part row.
+///   cq splits them into tool_calls and tool_results. The callID is the join key.
+fn create_oc_tool_calls_view(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_tool_calls AS
+        SELECT
+            p.session_id,
+            s.directory                                         AS project,
+            'opencode'                                          AS source,
+            p.message_id                                        AS message_uuid,
+            json_extract_string(p.data, '$.callID')            AS tool_use_id,
+            json_extract_string(p.data, '$.tool')              AS name,
+            json_extract(p.data, '$.state.input')              AS input,
+            epoch_ms(p.time_created)::VARCHAR                   AS timestamp,
+            NULL::VARCHAR                                       AS agent_id,
+            false                                               AS is_sidechain,
+            json_extract_string(oc_msg.data, '$.agent')        AS agent_type,
+            NULL::VARCHAR                                       AS workflow_id
+        FROM oc.part p
+        JOIN oc.message oc_msg ON oc_msg.id = p.message_id
+        JOIN oc.session s ON s.id = p.session_id
+        WHERE json_extract_string(p.data, '$.type') = 'tool'
+        ORDER BY p.time_created",
+    )
+    .context("create oc_tool_calls view")?;
+    Ok(())
+}
+
+/// cq tool_results equivalent.
+///
+/// Same part rows as oc_tool_calls; different columns surfaced.
+/// is_error: true when state.status != 'completed'.
+/// content: state.output (the stdout/result text).
+fn create_oc_tool_results_view(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_tool_results AS
+        SELECT
+            p.session_id,
+            s.directory                                                  AS project,
+            'opencode'                                                   AS source,
+            json_extract_string(p.data, '$.callID')                     AS tool_use_id,
+            (json_extract_string(p.data, '$.state.status') != 'completed'
+             AND json_extract_string(p.data, '$.state.status') IS NOT NULL)
+                                                                         AS is_error,
+            json_extract_string(p.data, '$.state.output')              AS content,
+            NULL::VARCHAR                                                AS agent_id,
+            false                                                        AS is_sidechain,
+            json_extract_string(oc_msg.data, '$.agent')                 AS agent_type,
+            NULL::VARCHAR                                                AS workflow_id
+        FROM oc.part p
+        JOIN oc.message oc_msg ON oc_msg.id = p.message_id
+        JOIN oc.session s ON s.id = p.session_id
+        WHERE json_extract_string(p.data, '$.type') = 'tool'
+        ORDER BY p.time_created",
+    )
+    .context("create oc_tool_results view")?;
+    Ok(())
+}
+
+fn print_section(conn: &Connection, title: &str, sql: &str) -> Result<()> {
+    println!("\n=== {} ===", title);
+    let mut stmt = conn.prepare(sql)?;
+    output::print_results(&mut stmt, &[], &OutputFormat::Default, false)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let db_path = opencode_db_path();
+    if !db_path.exists() {
+        eprintln!(
+            "opencode.db not found at {}\nInstall opencode and start a session first.",
+            db_path.display()
+        );
+        std::process::exit(1);
+    }
+
+    let args: Vec<String> = env::args().collect();
+    let show_messages = args.iter().any(|a| a == "--messages");
+    let show_tools = args.iter().any(|a| a == "--tools");
+
+    eprintln!("Connecting to {} ...", db_path.display());
+    let conn = setup(&db_path)?;
+
+    create_oc_sessions_view(&conn)?;
+    create_oc_messages_view(&conn)?;
+    create_oc_tool_calls_view(&conn)?;
+    create_oc_tool_results_view(&conn)?;
+
+    // Sessions (always shown)
+    print_section(
+        &conn,
+        "sessions (top-level, newest first)",
+        "SELECT session_id, project, source, started_at, ended_at,
+                message_count, tool_call_count, user_message_count,
+                subagent_count, first_user_message
+         FROM oc_sessions
+         LIMIT 10",
+    )?;
+
+    // Summary stats
+    print_section(
+        &conn,
+        "summary stats",
+        "SELECT
+            (SELECT COUNT(*) FROM oc_sessions)        AS sessions,
+            (SELECT COUNT(*) FROM oc_messages)        AS messages,
+            (SELECT COUNT(*) FROM oc_tool_calls)      AS tool_calls,
+            (SELECT COUNT(DISTINCT name) FROM oc_tool_calls) AS distinct_tools",
+    )?;
+
+    // Tool usage breakdown
+    print_section(
+        &conn,
+        "tool call counts by name",
+        "SELECT name, COUNT(*) AS calls
+         FROM oc_tool_calls
+         GROUP BY name
+         ORDER BY calls DESC",
+    )?;
+
+    if show_messages {
+        print_section(
+            &conn,
+            "messages (newest session)",
+            "SELECT session_id, uuid, type, timestamp, model, agent_type,
+                    tool_count, text
+             FROM oc_messages
+             WHERE session_id = (SELECT session_id FROM oc_sessions LIMIT 1)
+             ORDER BY timestamp",
+        )?;
+    }
+
+    if show_tools {
+        print_section(
+            &conn,
+            "tool_calls (newest session)",
+            "SELECT session_id, message_uuid, tool_use_id, name, timestamp, agent_type
+             FROM oc_tool_calls
+             WHERE session_id = (SELECT session_id FROM oc_sessions LIMIT 1)
+             ORDER BY timestamp",
+        )?;
+
+        print_section(
+            &conn,
+            "tool_results (newest session, first 5)",
+            "SELECT session_id, tool_use_id, is_error, agent_type, content
+             FROM oc_tool_results
+             WHERE session_id = (SELECT session_id FROM oc_sessions LIMIT 1)
+             ORDER BY session_id, tool_use_id
+             LIMIT 5",
+        )?;
+    }
+
+    Ok(())
+}

--- a/tests/opencode_spike.rs
+++ b/tests/opencode_spike.rs
@@ -1,0 +1,331 @@
+//! Prototype integration test: read opencode's SQLite DB via DuckDB, emit cq-shaped output.
+//!
+//! Run:
+//!   cargo test opencode_spike -- --nocapture --include-ignored
+//!
+//! Requires ~/.local/share/opencode/opencode.db (ignored if absent).
+//! Also requires the DuckDB sqlite extension (downloaded on first run; needs network).
+
+use duckdb::Connection;
+
+fn opencode_db_path() -> std::path::PathBuf {
+    dirs::home_dir()
+        .expect("no home dir")
+        .join(".local/share/opencode/opencode.db")
+}
+
+fn setup_opencode_connection() -> Connection {
+    let db_path = opencode_db_path();
+    let conn = Connection::open_in_memory().expect("open in-memory DuckDB");
+
+    conn.execute_batch("INSTALL sqlite; LOAD sqlite;")
+        .expect("install/load sqlite extension");
+
+    conn.execute_batch(&format!(
+        "ATTACH '{}' AS oc (TYPE sqlite, READ_ONLY);",
+        db_path.display()
+    ))
+    .expect("attach opencode.db");
+
+    conn
+}
+
+fn create_views(conn: &Connection) {
+    // sessions: one row per top-level session
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_sessions AS
+        SELECT
+            s.id                                    AS session_id,
+            s.directory                             AS project,
+            'opencode'                              AS source,
+            epoch_ms(s.time_created)::VARCHAR       AS started_at,
+            epoch_ms(s.time_updated)::VARCHAR       AS ended_at,
+            (SELECT COUNT(*) FROM oc.message m WHERE m.session_id = s.id) AS message_count,
+            (SELECT COUNT(*) FROM oc.part p
+             WHERE p.session_id = s.id
+               AND json_extract_string(p.data, '$.type') = 'tool') AS tool_call_count,
+            (SELECT COUNT(*) FROM oc.message m
+             WHERE m.session_id = s.id
+               AND json_extract_string(m.data, '$.role') = 'user') AS user_message_count,
+            (SELECT COUNT(*) FROM oc.session sub WHERE sub.parent_id = s.id) AS subagent_count,
+            s.title AS first_user_message
+        FROM oc.session s
+        WHERE s.parent_id IS NULL
+        ORDER BY s.time_created DESC",
+    ).expect("create oc_sessions");
+
+    // messages: one row per message
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_messages AS
+        SELECT
+            m.session_id,
+            s.directory                                         AS project,
+            'opencode'                                          AS source,
+            m.id                                               AS uuid,
+            json_extract_string(m.data, '$.parentID')          AS parent_uuid,
+            json_extract_string(m.data, '$.role')              AS type,
+            epoch_ms(m.time_created)::VARCHAR                   AS timestamp,
+            (SELECT json_extract_string(p.data, '$.text')
+             FROM oc.part p
+             WHERE p.message_id = m.id
+               AND json_extract_string(p.data, '$.type') = 'text'
+             LIMIT 1)                                           AS text,
+            (SELECT COUNT(*) FROM oc.part p
+             WHERE p.message_id = m.id
+               AND json_extract_string(p.data, '$.type') = 'tool') AS tool_count,
+            COALESCE(
+                json_extract_string(m.data, '$.modelID'),
+                json_extract_string(m.data, '$.model.modelID')
+            )                                                   AS model,
+            NULL::VARCHAR                                       AS agent_id,
+            false                                               AS is_sidechain,
+            json_extract_string(m.data, '$.agent')             AS agent_type,
+            NULL::VARCHAR                                       AS workflow_id
+        FROM oc.message m
+        JOIN oc.session s ON s.id = m.session_id
+        ORDER BY m.time_created",
+    ).expect("create oc_messages");
+
+    // tool_calls: one row per tool invocation
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_tool_calls AS
+        SELECT
+            p.session_id,
+            s.directory                                         AS project,
+            'opencode'                                          AS source,
+            p.message_id                                        AS message_uuid,
+            json_extract_string(p.data, '$.callID')            AS tool_use_id,
+            json_extract_string(p.data, '$.tool')              AS name,
+            json_extract(p.data, '$.state.input')              AS input,
+            epoch_ms(p.time_created)::VARCHAR                   AS timestamp,
+            NULL::VARCHAR                                       AS agent_id,
+            false                                               AS is_sidechain,
+            json_extract_string(oc_msg.data, '$.agent')        AS agent_type,
+            NULL::VARCHAR                                       AS workflow_id
+        FROM oc.part p
+        JOIN oc.message oc_msg ON oc_msg.id = p.message_id
+        JOIN oc.session s ON s.id = p.session_id
+        WHERE json_extract_string(p.data, '$.type') = 'tool'
+        ORDER BY p.time_created",
+    ).expect("create oc_tool_calls");
+
+    // tool_results: same part rows, different columns
+    conn.execute_batch(
+        "CREATE OR REPLACE VIEW oc_tool_results AS
+        SELECT
+            p.session_id,
+            s.directory                                                  AS project,
+            'opencode'                                                   AS source,
+            json_extract_string(p.data, '$.callID')                     AS tool_use_id,
+            (json_extract_string(p.data, '$.state.status') != 'completed'
+             AND json_extract_string(p.data, '$.state.status') IS NOT NULL)
+                                                                         AS is_error,
+            json_extract_string(p.data, '$.state.output')              AS content,
+            NULL::VARCHAR                                                AS agent_id,
+            false                                                        AS is_sidechain,
+            json_extract_string(oc_msg.data, '$.agent')                 AS agent_type,
+            NULL::VARCHAR                                                AS workflow_id
+        FROM oc.part p
+        JOIN oc.message oc_msg ON oc_msg.id = p.message_id
+        JOIN oc.session s ON s.id = p.session_id
+        WHERE json_extract_string(p.data, '$.type') = 'tool'
+        ORDER BY p.time_created",
+    ).expect("create oc_tool_results");
+}
+
+#[test]
+#[ignore]
+fn opencode_spike_sessions() {
+    let db_path = opencode_db_path();
+    if !db_path.exists() {
+        eprintln!("SKIP: {} not found", db_path.display());
+        return;
+    }
+
+    let conn = setup_opencode_connection();
+    create_views(&conn);
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM oc_sessions", [], |r| r.get(0))
+        .expect("count sessions");
+    println!("Top-level sessions: {}", count);
+    assert!(count > 0, "expected at least one session");
+
+    // Print summary
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, project, started_at, message_count,
+                    tool_call_count, user_message_count, subagent_count,
+                    first_user_message
+             FROM oc_sessions LIMIT 5",
+        )
+        .unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    println!(
+        "\n{:<32} {:<40} {:<26} {:>5} {:>6} {:>5} {:>5}",
+        "session_id", "project", "started_at", "msgs", "tools", "user", "subs"
+    );
+    println!("{}", "-".repeat(125));
+    while let Some(row) = rows.next().unwrap() {
+        let session_id: String = row.get(0).unwrap_or_default();
+        let project: String = row.get(1).unwrap_or_default();
+        let started_at: String = row.get(2).unwrap_or_default();
+        let message_count: i64 = row.get(3).unwrap_or(0);
+        let tool_call_count: i64 = row.get(4).unwrap_or(0);
+        let user_message_count: i64 = row.get(5).unwrap_or(0);
+        let subagent_count: i64 = row.get(6).unwrap_or(0);
+        // Truncate long fields for readability
+        let sid = &session_id[..session_id.len().min(32)];
+        let proj = if project.len() > 40 { &project[project.len() - 40..] } else { &project };
+        println!(
+            "{:<32} {:<40} {:<26} {:>5} {:>6} {:>5} {:>5}",
+            sid, proj, &started_at[..started_at.len().min(26)],
+            message_count, tool_call_count, user_message_count, subagent_count
+        );
+    }
+}
+
+#[test]
+#[ignore]
+fn opencode_spike_messages() {
+    let db_path = opencode_db_path();
+    if !db_path.exists() {
+        eprintln!("SKIP: {} not found", db_path.display());
+        return;
+    }
+
+    let conn = setup_opencode_connection();
+    create_views(&conn);
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM oc_messages", [], |r| r.get(0))
+        .expect("count messages");
+    println!("Total messages: {}", count);
+    assert!(count > 0);
+
+    // Verify required columns exist and have sensible types
+    let user_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oc_messages WHERE type = 'user'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let assistant_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oc_messages WHERE type = 'assistant'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    println!("  user: {}  assistant: {}", user_count, assistant_count);
+    assert!(user_count > 0);
+    assert!(assistant_count > 0);
+
+    // Check is_sidechain column type (should always be false)
+    let sidechain_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM oc_messages WHERE is_sidechain = true",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    println!("  sidechain rows: {}", sidechain_count);
+    assert_eq!(sidechain_count, 0, "all rows should be main-loop (is_sidechain=false)");
+}
+
+#[test]
+#[ignore]
+fn opencode_spike_tool_calls() {
+    let db_path = opencode_db_path();
+    if !db_path.exists() {
+        eprintln!("SKIP: {} not found", db_path.display());
+        return;
+    }
+
+    let conn = setup_opencode_connection();
+    create_views(&conn);
+
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM oc_tool_calls", [], |r| r.get(0))
+        .expect("count tool_calls");
+    println!("Total tool calls: {}", count);
+    assert!(count > 0);
+
+    println!("\nTool usage breakdown:");
+    let mut stmt = conn
+        .prepare("SELECT name, COUNT(*) AS calls FROM oc_tool_calls GROUP BY name ORDER BY calls DESC")
+        .unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        let name: String = row.get(0).unwrap_or_default();
+        let calls: i64 = row.get(1).unwrap_or(0);
+        println!("  {:20} {}", name, calls);
+    }
+
+    // tool_calls and tool_results should have same count (same underlying part rows)
+    let results_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM oc_tool_results", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, results_count, "tool_calls and tool_results should have same row count");
+}
+
+#[test]
+#[ignore]
+fn opencode_spike_full_demo() {
+    let db_path = opencode_db_path();
+    if !db_path.exists() {
+        eprintln!("SKIP: {} not found", db_path.display());
+        return;
+    }
+
+    let conn = setup_opencode_connection();
+    create_views(&conn);
+
+    println!("=== opencode -> cq schema prototype ===\n");
+
+    // Stats
+    let sessions: i64 = conn.query_row("SELECT COUNT(*) FROM oc_sessions", [], |r| r.get(0)).unwrap();
+    let messages: i64 = conn.query_row("SELECT COUNT(*) FROM oc_messages", [], |r| r.get(0)).unwrap();
+    let tools: i64 = conn.query_row("SELECT COUNT(*) FROM oc_tool_calls", [], |r| r.get(0)).unwrap();
+    let distinct_tools: i64 = conn
+        .query_row("SELECT COUNT(DISTINCT name) FROM oc_tool_calls", [], |r| r.get(0))
+        .unwrap();
+
+    println!("sessions:       {}", sessions);
+    println!("messages:       {}", messages);
+    println!("tool_calls:     {}", tools);
+    println!("distinct tools: {}", distinct_tools);
+
+    println!("\n--- sessions (newest 3) ---");
+    let mut stmt = conn
+        .prepare(
+            "SELECT session_id, project, source, started_at, message_count, tool_call_count, first_user_message
+             FROM oc_sessions LIMIT 3",
+        )
+        .unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        let sid: String = row.get(0).unwrap_or_default();
+        let project: String = row.get(1).unwrap_or_default();
+        let source: String = row.get(2).unwrap_or_default();
+        let started: String = row.get(3).unwrap_or_default();
+        let msgs: i64 = row.get(4).unwrap_or(0);
+        let tools_n: i64 = row.get(5).unwrap_or(0);
+        let title: String = row.get(6).unwrap_or_default();
+        println!("  {} | {} | {} | msgs={} tools={}", sid, source, started, msgs, tools_n);
+        println!("    project: {}", project);
+        println!("    title:   {}", &title[..title.len().min(80)]);
+    }
+
+    println!("\n--- tool call breakdown ---");
+    let mut stmt = conn
+        .prepare("SELECT name, COUNT(*) AS calls FROM oc_tool_calls GROUP BY name ORDER BY calls DESC")
+        .unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        let name: String = row.get(0).unwrap_or_default();
+        let calls: i64 = row.get(1).unwrap_or(0);
+        println!("  {:20} {}", name, calls);
+    }
+}


### PR DESCRIPTION
## What this is

A feasibility spike, not a merge candidate. It answers one question: can cq surface [opencode](https://opencode.ai) sessions, given that opencode stores everything in a single SQLite DB instead of Claude Code's JSONL-on-disk?

Answer: yes. DuckDB's `ATTACH ... (TYPE sqlite)` reads `opencode.db` directly, and the schema maps onto all four cq views (`sessions`, `messages`, `tool_calls`, `tool_results`). The mapping, the integration analysis, and the open questions live in `docs/opencode-source-findings.md` — that doc is the real deliverable.

## What maps, with wrinkles

- Timestamps are epoch-ms (need `/1000` + ISO formatting).
- Message text lives in `part` rows, not on the message itself; the initial prompt is in `session.title`.
- Sub-agents are separate sessions (`parent_id`), not in-message `agent_id` like Claude Code.

## The decision this sets up

Two integration paths, both written up in the findings doc:

- **(a) converter** — materialize opencode → Claude-compatible JSONL, zero cq core changes, but lossy and needs re-running.
- **(b) native `OpenCodeProvider`** — `ATTACH` the SQLite directly, no fidelity loss, but forces the `main.rs` polymorphic-dispatch refactor and breaks the `file_registry` mtime cache model (one append-only DB vs many files).

Recommendation: ship (a) as a bridge, then (b) for production after the dispatch refactor lands as its own PR.

## Verifying

The Rust artifacts (`examples/opencode_spike.rs`, `tests/opencode_spike.rs`) need ~3GB free disk for the bundled-duckdb recompile. The SQL logic was validated against a live `opencode.db`, so if the build is a hassle, run the queries from `docs/opencode-source-findings.md` against your own DB instead.
