### PR TITLE
Compose session views from per-provider SQL contributions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ commands/
   schema.rs       View schema docs + example queries (pure text, no DB needed)
 output.rs         Shared rendering: table (comfy-table) or JSON, accepts params
 style.rs          Terminal styling helpers (colors, dim/bold, TTY detection)
-views.rs          SQL view definitions (messages, tool_calls, tool_results, sessions) over the cached raw_records table
+views.rs          Per-provider view SQL (Claude bodies over raw_records) + the composer that UNION ALLs active providers' contributions into the four views; every row carries a `harness` column
 db.rs             Orchestrates cache open + indexer sync, registers views, returns DbSetup
 cache.rs          Persistent DuckDB cache at ~/.cache/cq/index.duckdb; schema versioning + rebuild
 indexer.rs        Incremental sync: file_registry + recursive mtime fast-path, fs2 file lock; recurses into <session>/subagents/** and captures agentType from meta.json
@@ -37,7 +37,7 @@ CQ is a query tool, not a monitoring tool. Default is auto-scope to the current 
 - **Persistent cache + incremental sync.** `cache.rs` opens the cache DB and handles schema versioning. `indexer.rs` walks files, checks mtime + size against `file_registry`, and only re-parses what changed. `fs2` file locking serializes concurrent writers; readers fall back to cached data when the lock is busy. The scan recurses into `<session>/subagents/**` (excluding `journal.jsonl`); subagent rows carry the parent `session_id` plus `is_sidechain`/`agent_id`/`agent_type`/`workflow_id` tags. The Auto mtime fast-path is a recursive max so new deep files are detected.
 - **SyncMode is explicit over smart.** `Auto` (default) does mtime fast-path + try-lock + skip-if-busy. `Force` (`--reindex`) waits for the lock and re-parses everything. `Skip` (`--no-reindex`) bypasses sync entirely. User flags always beat smart behavior.
 - **SyncScope narrows sync work.** A `--project` filter also restricts which files the indexer touches, not just which rows the query returns. Derived in `main.rs` from the CLI flags, passed through `db::setup_connection` into `indexer::sync`.
-- **Provider trait** abstracts file discovery. Only `ClaudeProvider` exists today but the trait allows other transcript sources.
+- **Provider trait** abstracts a transcript *harness*. Beyond file discovery, a provider has `prepare(conn) -> bool` (is it active?) and `contribute_view_sql(view)` (a SELECT body); `views::compose_views` UNION ALLs the active providers' contributions, tagging rows with a `harness` column. Only `ClaudeProvider` exists today (always active; its bodies read `raw_records`); the seam is built for a second harness to plug in.
 - **stderr for progress, stdout for data.** "Scanned N files" and "No results." go to stderr so piped output stays clean.
 - **Project paths are decoded in SQL.** `PROJECT_EXPR` in `views.rs` converts encoded directory names (e.g. `-Users-alice-myproject`) back to paths (`/Users/alice/myproject`).
 - **ILIKE for project filtering.** `--project` does substring match, not exact.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,28 @@
+# cq
+
+cq queries AI coding-session transcripts with SQL. It indexes transcripts into a DuckDB cache and exposes four views (`sessions`, `messages`, `tool_calls`, `tool_results`). This context defines the terms cq uses to talk about *where transcripts come from*, since more than one tool can produce them.
+
+## Language
+
+**Harness**:
+The tool that produced the transcripts — Claude Code, opencode. Distinct harnesses store transcripts in fundamentally different shapes (Claude Code: a tree of JSONL files; opencode: one append-only SQLite DB).
+_Avoid_: "source" for this meaning (see below), "client", "agent".
+
+**Provider**:
+The cq component that knows how to read one **Harness**'s storage. `ClaudeProvider` exists today; `OpenCodeProvider` is planned. Modeled by the `TranscriptProvider` trait, though the runtime path does not yet dispatch through it polymorphically.
+_Avoid_: "adapter", "backend".
+
+**Source**:
+A named JSONL transcript root *within the Claude provider*: `"main"` (`~/.claude/projects`) plus one per discovered cenv env. This is what `--source` selects. It is **not** the cross-harness concept — opencode is a new **Provider**, not a new **Source**.
+_Avoid_: using "source" to mean a different harness.
+
+## Relationships
+
+- A **Harness** is read by exactly one **Provider**.
+- The Claude **Provider** spans one or more **Sources** (main + cenv envs); `--source` scopes within it.
+- The opencode **Provider** has no **Sources** in the current sense — its storage is a single SQLite DB, not a directory of JSONL roots.
+- The `source` column in the cq views is really a **harness/provider** tag (`'claude'` / `'opencode'`), distinct from the `--source` flag's within-Claude meaning. (Flagged below.)
+
+## Flagged ambiguities
+
+- "source" was used in the opencode findings doc to mean "a new harness" (`'opencode'` source). Resolved: that is a **Provider**/**Harness**, not a **Source**. cq's existing `Source` keeps its narrow within-Claude meaning. The overload on the views' `source` column vs. the `--source` flag is a known wart to resolve when designing the views.

--- a/docs/adr/0001-opencode-via-live-attach.md
+++ b/docs/adr/0001-opencode-via-live-attach.md
@@ -1,0 +1,22 @@
+# opencode is a live-ATTACHed Provider, not a cached Source
+
+**Status:** accepted
+
+cq reads opencode sessions as a new **Provider** (peer to `ClaudeProvider`), querying opencode's single SQLite DB live via DuckDB `ATTACH ... (TYPE sqlite, READ_ONLY)` on every invocation. opencode rows are **never written to the persistent cache** (`raw_records`/`file_registry`). The four views become `claude_<view> UNION ALL opencode_<view>`, composed at runtime from whichever providers prepared successfully.
+
+## Why
+
+- opencode is a different *harness* with a fundamentally different storage shape (one append-only SQLite DB vs. Claude's tree of JSONL files). Modeling it as another `Source` (cq's within-Claude "a JSONL projects dir" concept) would be a category error — see `CONTEXT.md`.
+- Not caching opencode **deletes the hardest open question**: an append-only single-file DB has no clean per-file mtime/size cursor for incremental indexing. Live ATTACH over a local SQLite file is milliseconds and always fresh, so the cache buys nothing here. The "freshness = has this been indexed" principle bends gracefully: a no-index provider is always current.
+- The decision is reversible at the view-contract level: if opencode.db ever grows enough to matter, a caching/materialization step can be added behind the same `contribute_view_sql` seam without changing what queries see.
+
+## Considered and rejected
+
+- **(a) Converter to Claude-style JSONL.** Makes opencode masquerade as a Claude `Source` (the collision above), loses cost/token data, and goes stale. Rejected.
+- **(b-materialize) `INSERT INTO raw_records` during sync.** Same lossy re-encoding as (a) and revives the mtime-cursor problem. Rejected.
+- **Static-bundle the DuckDB `sqlite_scanner`.** Real build-system investment (`duckdb-rs`'s `bundled` feature doesn't expose it). Deferred unless cq ships as a binary where a one-time first-run network fetch is unacceptable.
+
+## Consequences
+
+- Reading opencode requires DuckDB's `sqlite` extension. We `INSTALL`+`LOAD` at runtime (cached in `~/.duckdb/` after first online fetch). If it can't load, `OpenCodeProvider` **degrades gracefully** — contributes no views, warns on stderr, and Claude queries are unaffected ("stale-but-available beats error"). The one-time `INSTALL` needs network (will fail under Claude Code's sandbox until cached).
+- A new **`harness`** column (`'claude'`/`'opencode'`) is added to all four views, distinct from the within-Claude `--source` dimension.

--- a/docs/opencode-source-findings.md
+++ b/docs/opencode-source-findings.md
@@ -1,0 +1,332 @@
+# opencode Source: Findings & Design Input
+
+This document captures the schema mapping, integration analysis, and open design
+questions for wiring opencode session data into cq's existing views.
+
+## Status
+
+Prototype complete. SQL queries validated against a live
+`~/.local/share/opencode/opencode.db` (v1.17.5 format). Rust code artifacts
+in `examples/opencode_spike.rs` and `tests/opencode_spike.rs` compile but
+require ~3GB free disk to build from source.
+
+## Schema mapping
+
+### sessions view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `session.id` | Different namespace (`ses_...` prefix) |
+| `project` | `session.directory` | Real path; no encoding/decoding needed |
+| `source` | constant `'opencode'` | |
+| `started_at` | `session.time_created` (epoch ms) | Needs `/1000` and ISO 8601 format conversion |
+| `ended_at` | `session.time_updated` (epoch ms) | Same conversion |
+| `message_count` | COUNT from `message` table | |
+| `tool_call_count` | COUNT of `part` rows with `data.type='tool'` | |
+| `user_message_count` | COUNT of `message` rows with `data.role='user'` | |
+| `subagent_count` | COUNT of `session` rows with `parent_id = s.id` | Different model: sub-agents are sessions not in-message |
+| `first_user_message` | `session.title` | opencode sets title to the initial prompt |
+
+Missing from opencode: nothing critical absent; `session.model` (JSON) is extra data available.
+
+### messages view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `message.session_id` | |
+| `project` | via `session.directory` JOIN | |
+| `source` | constant `'opencode'` | |
+| `uuid` | `message.id` | Different namespace (`msg_...` prefix) |
+| `parent_uuid` | `json_extract(message.data, '$.parentID')` | |
+| `type` | `json_extract(message.data, '$.role')` | Values: `user`, `assistant` |
+| `timestamp` | `message.time_created` (epoch ms) | ISO 8601 conversion needed |
+| `text` | `part.data.text` where `part.data.type='text'` | Text NOT in message.data; lives in part table |
+| `tool_count` | COUNT of `part` rows with `data.type='tool'` for this message | |
+| `model` | `message.data.modelID` (assistant) OR `message.data.model.modelID` (user) | Different path by role |
+| `agent_id` | NULL | Sub-agents are sessions, not in-message IDs |
+| `is_sidechain` | false | Main loop only; sub-sessions handled via parent_id |
+| `agent_type` | `json_extract(message.data, '$.agent')` | Values: `build`, `general`, etc. |
+| `workflow_id` | NULL | opencode has no workflow concept |
+
+Key gap: `text` for user messages comes from part rows (type='text'), not from the
+message's own data column. The initial user prompt text is in `session.title` instead.
+
+### tool_calls view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `part.session_id` | |
+| `project` | via `session.directory` JOIN | |
+| `source` | constant `'opencode'` | |
+| `message_uuid` | `part.message_id` | |
+| `tool_use_id` | `json_extract(part.data, '$.callID')` | String (opencode) vs string (cq); join key |
+| `name` | `json_extract(part.data, '$.tool')` | e.g. `bash`, `read`, `write`, `grep`, `task` |
+| `input` | `json_extract(part.data, '$.state.input')` | JSON object, maps cleanly |
+| `timestamp` | `part.time_created` (epoch ms) | |
+| `agent_id` | NULL | |
+| `is_sidechain` | false | |
+| `agent_type` | via `message.data.agent` JOIN | |
+| `workflow_id` | NULL | |
+
+### tool_results view
+
+| cq column | opencode source | Notes |
+|-----------|----------------|-------|
+| `session_id` | `part.session_id` | |
+| `project` | via `session.directory` JOIN | |
+| `source` | constant `'opencode'` | |
+| `tool_use_id` | `json_extract(part.data, '$.callID')` | Same part row as tool_calls |
+| `is_error` | `part.data.state.status != 'completed'` | 49 completed / 1 error in live data |
+| `content` | `json_extract(part.data, '$.state.output')` | The stdout/result text |
+| `agent_id` | NULL | |
+| `is_sidechain` | false | |
+| `agent_type` | via `message.data.agent` JOIN | |
+| `workflow_id` | NULL | |
+
+## Key structural difference: tool call/result co-location
+
+In cq/Claude Code, a tool call (the request) and tool result (the response) are
+separate JSONL records. They join on `tool_use_id`.
+
+In opencode, both live in the SAME `part` row: `state.input` is the call,
+`state.output` is the result. The `callID` field is the equivalent of `tool_use_id`.
+
+This means:
+- `tool_calls` and `tool_results` views over opencode produce the SAME row count.
+- The join key (`callID` = `tool_use_id`) works correctly.
+- No "pending tool call without result" rows exist in opencode (call and result are
+  atomic from the DB perspective).
+
+## Does the data map cleanly?
+
+Yes, with three predictable wrinkles:
+
+1. **Timestamp units.** opencode stores all times as epoch milliseconds (BIGINT).
+   cq stores timestamps as ISO 8601 VARCHAR strings. A native provider needs to emit
+   ISO 8601 from the SQL (DuckDB: `strftime(epoch_ms(t), format)`; SQLite:
+   `datetime(t/1000, 'unixepoch')`).
+
+2. **Text content is in parts, not messages.** The user message text field requires
+   a subquery against the `part` table. The initial user prompt is in `session.title`
+   rather than appearing as a separate text part (it's the session's title).
+
+3. **Sub-agents are sessions, not in-message IDs.** cq uses `agent_id` (an in-message
+   field) to identify sub-agent work; opencode creates a full child session with
+   `parent_id` pointing to the parent. Mapping: `agent_id = NULL` everywhere,
+   `subagent_count = COUNT(child sessions)`. The cq concepts `is_sidechain` and
+   `workflow_id` have no equivalent in opencode.
+
+No data is lost; the gaps (`agent_id`, `is_sidechain`, `workflow_id`) all NULL-out
+cleanly.
+
+## Timestamp conversion
+
+opencode: `time_created INTEGER` (epoch milliseconds, e.g. `1781732636455`)
+
+DuckDB conversion: `strftime(epoch_ms(time_created), '%Y-%m-%dT%H:%M:%SZ')`
+
+SQLite conversion (for testing): `datetime(time_created/1000, 'unixepoch')`
+
+cq currently stores timestamps as VARCHAR ISO 8601 strings. A native OpenCode
+provider would need to emit the same format for string comparisons in the sessions
+view (`MIN(timestamp)`, `MAX(timestamp)`) to work correctly.
+
+## Integration path analysis
+
+### Option (a): Converter materialization
+
+Convert opencode sessions to Claude Code-compatible JSONL in a temp directory, then
+let the existing `ClaudeProvider` index them.
+
+**What this costs:**
+- Write a one-shot converter (Rust or shell) that reads opencode.db and writes JSONL
+  files in the format `<projects_dir>/<encoded-project>/<session-id>.jsonl`.
+- The converter must translate each `(session, message, part)` triple into cq's
+  existing JSON envelope: `{ "type": "user"|"assistant", "uuid": "...", "sessionId":
+  "...", "timestamp": "...", "message": { "content": [...] } }`.
+- The directory layout must match what `ClaudeProvider` expects.
+- The converter output is ephemeral (temp dir) or persistent (synced dir).
+- No changes to cq's core codebase.
+
+**What it doesn't cost:**
+- No changes to `main.rs` provider dispatch.
+- No changes to `indexer.rs` or `views.rs`.
+- Can be implemented entirely outside the cq codebase.
+
+**Drawbacks:**
+- Data fidelity: some opencode fields (cost, token breakdown, diffs) are not in
+  cq's JSONL schema and would be dropped.
+- Staleness: the converter must be re-run when opencode adds sessions.
+- The produced JSONL is a translation artifact, not the real data.
+- Tool call/result co-location needs careful splitting into separate JSONL records.
+
+### Option (b): Native OpenCodeProvider
+
+A new `OpenCodeProvider` that implements `TranscriptProvider` and reads opencode.db
+directly, generating cq views that query the SQLite tables.
+
+**What this costs:**
+- A new provider struct in `src/opencode_provider.rs`.
+- `register_views()` must create SQL views reading from the attached SQLite DB
+  (DuckDB's `ATTACH ... (TYPE sqlite)` mechanism).
+- The `main.rs` dispatch refactor: today `ClaudeProvider` is constructed directly
+  (`~line 209`); the code does not use the `TranscriptProvider` trait polymorphically.
+  A second provider forces this refactor (likely `Box<dyn TranscriptProvider>`).
+- `indexer.rs` assumes `read_json` over JSONL files; the SQLite source breaks this
+  assumption. The indexer would need a bypass or a separate "sqlite source" code
+  path. The `file_registry` mtime/size model does not apply to a single DB file.
+- `cache.rs` schema (`file_registry`) stores per-file mtime/size. A SQLite source
+  would need a different freshness mechanism (e.g., check opencode.db mtime).
+- Views that reference `source_file` (currently all four cq views do) would need
+  alternatives for the non-JSONL case.
+
+**What it doesn't cost:**
+- No data fidelity loss; native SQL over the real tables.
+- No converter maintenance.
+- Automatically reflects new sessions.
+
+### Recommendation
+
+For the immediate spike/integration: **start with (a)**. The converter approach
+lets you validate the schema mapping with zero changes to the cq codebase. The
+JSONL output can be pointed at with `CQ_PROJECTS_DIR` in tests.
+
+For the production integration: **(b) is the right long-term answer**, but only
+after the `main.rs` polymorphic dispatch refactor is done as a separate PR. The
+refactor is ~50 lines of straightforward Rust but it touches the cq startup path
+and deserves its own review.
+
+The two paths are not mutually exclusive: ship (a) as the cq v1.x opencode bridge,
+then replace it with (b) in v2.
+
+## SQLite source and the mtime cache model
+
+cq's incremental cache uses `file_registry(file_path, mtime_ns, file_size)` to
+decide what to re-parse. A SQLite source breaks this in two ways:
+
+1. There's ONE file (`opencode.db`) not many JSONL files. The "file" is the whole DB.
+2. opencode.db is append-only; a change in mtime means "there's new data," not "this
+   whole file changed." The indexer would over-index (re-reading everything on any
+   DB change) unless it tracks some other cursor (e.g., `MAX(time_updated)` from
+   the session table, or the sqlite `wal` checkpoint sequence).
+
+The cleanest approach for (b): store the DB path in `file_registry` with the opencode.db
+mtime. When mtime changes, run a "delta scan" that queries `WHERE time_created > last_seen`.
+This needs a new column in `file_registry` (e.g., `cursor BIGINT`) to store the last
+`MAX(session.time_updated)` seen.
+
+Option (a) sidesteps this entirely: the converter controls the JSONL files, which
+have normal mtimes.
+
+## Open questions for the design step
+
+> **Resolved 2026-06-18** in a grill-with-docs design session. See the
+> "Design resolutions" section below and `docs/adr/0001-opencode-via-live-attach.md`.
+> The questions are kept here for the reasoning trail.
+
+1. **Provider dispatch refactor scope.** How disruptive is the `main.rs` refactor
+   to go from `ClaudeProvider` directly to `Box<dyn TranscriptProvider>`? Are there
+   other callers that would also need updating?
+
+2. **Sub-agent representation.** opencode's parent_id sub-sessions vs cq's in-message
+   `agent_id`. For the production integration: should opencode sub-sessions be
+   surfaced as first-class sessions (with `is_sidechain = true` on the parent's
+   messages)? Or should they be flattened? The current prototype nulls both out.
+
+3. **Source column in the cache.** `file_registry.source` was added for the
+   multi-source PR. A SQLite source with no JSONL files needs a different key.
+   What's the canonical "file path" for an opencode source row?
+
+4. **Scope filtering.** `cq sessions --project .` scans the current directory
+   against `project` in the sessions view. For opencode, `project = session.directory`
+   (real path). The ILIKE match should work as-is. Verify this.
+
+5. **Token / cost data.** opencode tracks `cost`, `tokens_input/output/reasoning/
+   cache_read/cache_write` per session. cq currently has no cost/tokens in any view.
+   Worth adding to the sessions view in a future PR?
+
+6. **DuckDB sqlite extension bundling.** The prototype uses `INSTALL sqlite` which
+   downloads the extension from DuckDB's servers on first use. For a production
+   integration, we'd want this bundled or pre-installed. The `libduckdb-sys` crate
+   has a `duckdb-loadable-extension` feature but not a bundled sqlite scanner.
+   How does the extension get delivered?
+
+## Design resolutions (2026-06-18)
+
+Vocabulary settled in `CONTEXT.md`: **Harness** (Claude Code, opencode) is read by
+a **Provider** (`ClaudeProvider`, `OpenCodeProvider`); **Source** keeps its narrow
+within-Claude meaning (main + cenv JSONL roots, selected by `--source`). opencode
+is a new Provider, not a new Source. Architecture recorded in
+`docs/adr/0001-opencode-via-live-attach.md`.
+
+**Core architecture: live ATTACH, never cached.** `OpenCodeProvider` queries
+opencode.db live via DuckDB `ATTACH ... (TYPE sqlite, READ_ONLY)`; rows are never
+written to `raw_records`/`file_registry`. This deletes the mtime-cursor problem
+(Q3's append-only-DB headache) entirely — a no-index provider is always fresh.
+
+**Ship in two PRs:**
+
+- **PR 1 — Claude-only no-op refactor.** Build a provider collection in `main.rs`
+  instead of the hardcoded `ClaudeProvider::new()`. Generalize the trait to two
+  phases: `prepare(conn)` (Claude: sync JSONL → `raw_records`; the seam where
+  opencode will `ATTACH`) and `contribute_view_sql(view) -> Option<String>`. Add a
+  view **composer** that `UNION ALL`s contributions (trivial pass-through with one
+  provider, so all tests stay green). Establish the new **`harness`** column
+  (`'claude'`/`'opencode'`) in the view contract; Claude contributes `'claude'`.
+  Claude-specific scope/`--source` plumbing (`project_for_cwd`,
+  `source_for_config_dir`, `sources`, `project_dirs_for_query`) stays inherent to
+  `ClaudeProvider`, off the trait.
+- **PR 2 — `OpenCodeProvider`.** `prepare` = `INSTALL sqlite; LOAD sqlite; ATTACH`;
+  `contribute_view_sql` = the SELECTs below. Added only when opencode.db exists.
+
+**Resolution by question:**
+
+1. *Refactor scope* → bigger than "swap a constructor": the runtime path
+   (`setup_connection` → `sync_sources`) bypasses the trait and is hardwired to the
+   `(name, projects_dir)` JSONL shape. Real job = collect view-SQL from active
+   providers and compose with `UNION ALL`. Done as PR 1 above.
+2. *Sub-agents* → **first-class sessions, real IDs preserved.** Derive
+   `is_sidechain = (session.parent_id IS NOT NULL)` (cheap JOIN; do NOT rewrite child
+   `session_id` into the parent). `agent_id = NULL`. `agent_type` from
+   `message.data.agent`. `subagent_count` = count of child sessions. (Live data: 3 of
+   11 sessions are sub-agents, so this is real, not hypothetical.)
+3. *Source column / canonical path* → new **`harness`** column, distinct from the
+   within-Claude `--source`. opencode rows have no `file_registry`/`source_file`
+   entry; opencode SELECTs supply `NULL` for those columns.
+4. *Scope filtering* → opencode `project = session.directory` (real path), existing
+   `ILIKE` works. Verify in PR 2.
+5. *Token / cost* → **deferred** to a later, harness-aware PR (asymmetric: Claude has
+   no cost, tokens need per-message aggregation).
+6. *sqlite extension delivery* → **runtime `INSTALL`+`LOAD` with graceful degrade.**
+   If the extension can't load, `OpenCodeProvider.prepare` returns "inactive":
+   contributes no views, and warns on stderr *only* when opencode.db exists (or
+   `--harness opencode` was explicitly requested). Claude queries are unaffected
+   ("stale-but-available beats error"). The one-time `INSTALL` needs network (fails
+   under Claude Code's sandbox until cached in `~/.duckdb/`). Static bundling deferred.
+
+### Schema drift caught against live opencode.db (v as of 2026-06-17)
+
+The prototype's *session* SQL is partially stale: the `session` table has
+**flattened** — `cost`, `tokens_input/output/reasoning/cache_read/cache_write`,
+`agent`, `model`, `directory`, `title`, `parent_id` are now real columns, not JSON in
+a `data` blob. The `message` and `part` tables still carry a JSON `data` blob, so the
+prototype's `json_extract` SQL holds *there* (`message.data.role`/`.agent`;
+`part.data.type` ∈ `text|tool|patch|reasoning|step-start|step-finish`; tool parts have
+`.tool`/`.callID`/`.state.status`/`.state.input`/`.state.output`). PR 2 must refresh
+the session-level SELECT to read flat columns.
+
+### Reference SELECT (sessions view, opencode contribution)
+
+```sql
+SELECT
+  s.id                                                     AS session_id,
+  s.directory                                              AS project,
+  'opencode'                                               AS harness,
+  strftime(epoch_ms(s.time_created), '%Y-%m-%dT%H:%M:%SZ') AS started_at,
+  strftime(epoch_ms(s.time_updated), '%Y-%m-%dT%H:%M:%SZ') AS ended_at,
+  (SELECT COUNT(*) FROM oc.message m WHERE m.session_id = s.id) AS message_count,
+  (SELECT COUNT(*) FROM oc.session c WHERE c.parent_id = s.id)  AS subagent_count,
+  (s.parent_id IS NOT NULL)                                AS is_sidechain,
+  s.title                                                  AS first_user_message
+FROM oc.session s
+```

--- a/docs/superpowers/plans/2026-06-18-cq-provider-composition-refactor.md
+++ b/docs/superpowers/plans/2026-06-18-cq-provider-composition-refactor.md
@@ -1,0 +1,681 @@
+# cq Provider-Composition Refactor (PR 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor cq's view registration so the four SQL views (`messages`, `tool_calls`, `tool_results`, `sessions`) are composed from per-provider SQL contributions via `UNION ALL`, and add a `harness` column to the view contract — all with zero behavior change for the only current provider (Claude).
+
+**Architecture:** Today `db::setup_connection` hardcodes the indexer sync then calls `views::register_derived_views`, which builds the four views directly over the `raw_records` cache table. This PR introduces a `View` enum and two new `TranscriptProvider` trait methods — `prepare(&Connection) -> Result<bool>` (is this provider active?) and `contribute_view_sql(View) -> Option<String>` (a SELECT *body* for one view) — plus a `views::compose_views` composer that wraps each active provider's body in parens and `UNION ALL`s them into the final view. With Claude as the sole provider, every view is a single-contribution pass-through, so existing tests stay green. The new `harness` column is `'claude'` for all Claude rows. PR 2 (`OpenCodeProvider`, separate plan) plugs into this seam.
+
+**Tech Stack:** Rust, DuckDB (`duckdb` crate `=1.10501.0`, bundled), `anyhow`, `cargo test`.
+
+---
+
+## Context the implementer needs
+
+- **Run tests:** `cargo test` from `repos/cq/worktrees/opencode-source-prototype`. The first build compiles DuckDB from source (~3GB, several minutes). Subsequent builds are fast.
+- **The three test files:** `tests/views_test.rs` (view SQL correctness against JSONL fixtures), `tests/integration_test.rs` (end-to-end CLI), `src/*.rs` unit tests. The view tests build views via `cq::views::register_views(&conn, &paths)` after manually creating a `file_registry` table — see `setup_db` / `setup_db_multi` helpers at the top of `tests/views_test.rs`.
+- **Why `harness` must be in `sessions` AND filtered:** `register_sessions_view` aggregates `FROM messages GROUP BY session_id`. Once `messages` is a `UNION` across providers (PR 2), an unfiltered Claude `sessions` body would aggregate opencode rows too. Adding `WHERE harness = 'claude'` to the Claude `sessions` body is a no-op today (all rows are Claude) and prevents that latent bug. Bake it in now.
+- **`prepare` is deliberately trivial for Claude in this PR.** The JSONL→`raw_records` sync stays in `db.rs`/`indexer.rs` (it's Claude-specific machinery PR 2 doesn't touch). `ClaudeProvider::prepare` just returns `Ok(true)`. The method exists to establish the seam; `OpenCodeProvider::prepare` (PR 2) is where it does real work (`INSTALL`/`LOAD`/`ATTACH`).
+- **Docs-in-sync rule:** `CLAUDE.md` requires that behavior changes update matching docs. The new `harness` column touches `src/commands/schema.rs` (view column docs) and the README/CLAUDE.md view tables. Task 6 covers this.
+- **Column placement:** put `harness` immediately after the existing `source` column in every view, for a stable, readable column order.
+
+---
+
+## File Structure
+
+- `src/provider.rs` — **Modify.** Add `View` enum; add `prepare` + `contribute_view_sql` to the `TranscriptProvider` trait (with default impls so non-Claude code compiles).
+- `src/views.rs` — **Modify.** Extract the four Claude view bodies into `pub` body-builder functions returning `String` (each gaining `harness`); add `compose_views` + `empty_view_sql`; rewire `register_views`/`register_derived_views` through the composer.
+- `src/claude_provider.rs` — **Modify.** Implement `prepare` (returns `Ok(true)`) and `contribute_view_sql` (delegates to the `views::claude_*_sql` body functions).
+- `src/db.rs` — **Modify.** `setup_connection` takes the provider list, runs `prepare` on each to get the active set, and calls `compose_views` instead of `register_derived_views`.
+- `src/main.rs` — **Modify.** Build `Vec<Box<dyn TranscriptProvider>>` (just Claude for now) and pass it to `setup_connection`.
+- `src/commands/schema.rs` — **Modify.** Add `harness` to the documented column lists.
+- `tests/views_test.rs` — **Modify.** Add `harness`-column regression tests; fix any column-set assertions broken by the new column.
+- `README.md`, `CLAUDE.md` — **Modify.** Add `harness` to the view column tables.
+
+---
+
+## Task 1: Add the `View` enum and extend the `TranscriptProvider` trait
+
+**Files:**
+- Modify: `src/provider.rs`
+
+- [ ] **Step 1: Add the `View` enum and trait methods**
+
+In `src/provider.rs`, add the enum below the imports and extend the trait. The two new methods get default impls so the trait stays object-safe and existing impls compile until updated:
+
+```rust
+/// The four queryable views cq composes from provider contributions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum View {
+    Messages,
+    ToolCalls,
+    ToolResults,
+    Sessions,
+}
+
+impl View {
+    /// All views in dependency order. `Sessions` aggregates over `messages`,
+    /// so `Messages` must be composed before `Sessions`.
+    pub const ALL: [View; 4] = [View::Messages, View::ToolCalls, View::ToolResults, View::Sessions];
+
+    /// The SQL view name.
+    pub fn name(self) -> &'static str {
+        match self {
+            View::Messages => "messages",
+            View::ToolCalls => "tool_calls",
+            View::ToolResults => "tool_results",
+            View::Sessions => "sessions",
+        }
+    }
+}
+
+pub trait TranscriptProvider {
+    fn name(&self) -> &str;
+    fn discover_files(&self, scope: &QueryScope) -> Result<Vec<PathBuf>>;
+    fn register_views(&self, conn: &Connection, files: &[PathBuf]) -> Result<()>;
+    fn list_projects(&self) -> Result<Vec<ProjectInfo>>;
+
+    /// Prepare the connection for this provider and report whether it is active
+    /// (should contribute views). Claude: returns Ok(true). Future providers may
+    /// ATTACH external storage here and return Ok(false) to sit out gracefully.
+    fn prepare(&self, _conn: &Connection) -> Result<bool> {
+        Ok(true)
+    }
+
+    /// The SQL SELECT *body* (no `CREATE VIEW` wrapper) this provider contributes
+    /// for `view`, or None if it contributes nothing. The composer wraps each body
+    /// in parens and `UNION ALL`s contributions from all active providers.
+    fn contribute_view_sql(&self, _view: View) -> Option<String> {
+        None
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo build`
+Expected: PASS (warnings about unused `View` are fine at this point).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/provider.rs
+git commit -m "refactor: add View enum and prepare/contribute_view_sql trait methods"
+```
+
+---
+
+## Task 2: Extract Claude view bodies into functions and add the `harness` column
+
+**Files:**
+- Modify: `src/views.rs`
+
+This task extracts the inner SQL of each `register_*_view` function into a `pub fn claude_*_sql() -> String` that returns just the SELECT body (no `CREATE OR REPLACE VIEW ... AS`), with `'claude' AS harness` added. The existing `register_*_view` functions will be removed in Task 3 (replaced by the composer), so here we only *add* the body functions.
+
+- [ ] **Step 1: Add `claude_messages_sql`**
+
+Add to `src/views.rs`. This is the body from `register_messages_view`, with `'claude' AS harness` added after `source` in both CTEs:
+
+```rust
+/// The Claude `messages` view body (SELECT only, no CREATE VIEW wrapper).
+pub fn claude_messages_sql() -> String {
+    format!("WITH string_msgs AS (
+            SELECT
+                json_extract_string(json, '$.sessionId') AS session_id,
+                {PROJECT_EXPR} AS project,
+                {SOURCE_EXPR} AS source,
+                'claude' AS harness,
+                json_extract_string(json, '$.uuid') AS uuid,
+                json_extract_string(json, '$.parentUuid') AS parent_uuid,
+                json_extract_string(json, '$.type') AS type,
+                json_extract_string(json, '$.timestamp') AS timestamp,
+                json_extract_string(json, '$.message.content') AS text,
+                CAST(0 AS BIGINT) AS tool_count,
+                json_extract_string(json, '$.message.model') AS model,
+                {AGENT_ID_EXPR} AS agent_id,
+                {IS_SIDECHAIN_EXPR} AS is_sidechain,
+                {AGENT_TYPE_EXPR} AS agent_type,
+                {WORKFLOW_ID_EXPR} AS workflow_id
+            FROM raw_records
+            WHERE json_extract_string(json, '$.type') IN ('user', 'assistant')
+            AND json_type(json_extract(json, '$.message.content')) = 'VARCHAR'
+        ),
+        array_msgs AS (
+            SELECT
+                json_extract_string(json, '$.sessionId') AS session_id,
+                {PROJECT_EXPR} AS project,
+                {SOURCE_EXPR} AS source,
+                'claude' AS harness,
+                json_extract_string(json, '$.uuid') AS uuid,
+                json_extract_string(json, '$.parentUuid') AS parent_uuid,
+                json_extract_string(json, '$.type') AS type,
+                json_extract_string(json, '$.timestamp') AS timestamp,
+                (SELECT json_extract_string(item, '$.text')
+                 FROM (SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item)
+                 WHERE json_extract_string(item, '$.type') = 'text'
+                 LIMIT 1) AS text,
+                CASE WHEN json_extract_string(json, '$.type') = 'assistant' THEN
+                    (SELECT COUNT(*)
+                     FROM (SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item)
+                     WHERE json_extract_string(item, '$.type') = 'tool_use')
+                ELSE CAST(0 AS BIGINT)
+                END AS tool_count,
+                json_extract_string(json, '$.message.model') AS model,
+                {AGENT_ID_EXPR} AS agent_id,
+                {IS_SIDECHAIN_EXPR} AS is_sidechain,
+                {AGENT_TYPE_EXPR} AS agent_type,
+                {WORKFLOW_ID_EXPR} AS workflow_id
+            FROM raw_records
+            WHERE json_extract_string(json, '$.type') IN ('user', 'assistant')
+            AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
+        )
+        SELECT * FROM string_msgs
+        UNION ALL
+        SELECT * FROM array_msgs")
+}
+```
+
+- [ ] **Step 2: Add `claude_tool_calls_sql`**
+
+```rust
+/// The Claude `tool_calls` view body.
+pub fn claude_tool_calls_sql() -> String {
+    format!("SELECT
+            json_extract_string(json, '$.sessionId') AS session_id,
+            {PROJECT_EXPR} AS project,
+            {SOURCE_EXPR} AS source,
+            'claude' AS harness,
+            json_extract_string(json, '$.uuid') AS message_uuid,
+            json_extract_string(item, '$.id') AS tool_use_id,
+            json_extract_string(item, '$.name') AS name,
+            json_extract(item, '$.input') AS input,
+            json_extract_string(json, '$.timestamp') AS timestamp,
+            {AGENT_ID_EXPR} AS agent_id,
+            {IS_SIDECHAIN_EXPR} AS is_sidechain,
+            {AGENT_TYPE_EXPR} AS agent_type,
+            {WORKFLOW_ID_EXPR} AS workflow_id
+        FROM raw_records,
+        LATERAL (
+            SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item
+        )
+        WHERE json_extract_string(json, '$.type') = 'assistant'
+        AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
+        AND json_extract_string(item, '$.type') = 'tool_use'")
+}
+```
+
+- [ ] **Step 3: Add `claude_tool_results_sql`**
+
+```rust
+/// The Claude `tool_results` view body.
+pub fn claude_tool_results_sql() -> String {
+    format!("SELECT
+            json_extract_string(json, '$.sessionId') AS session_id,
+            {PROJECT_EXPR} AS project,
+            {SOURCE_EXPR} AS source,
+            'claude' AS harness,
+            json_extract_string(item, '$.tool_use_id') AS tool_use_id,
+            COALESCE(CAST(json_extract(item, '$.is_error') AS BOOLEAN), false) AS is_error,
+            json_extract_string(item, '$.content') AS content,
+            {AGENT_ID_EXPR} AS agent_id,
+            {IS_SIDECHAIN_EXPR} AS is_sidechain,
+            {AGENT_TYPE_EXPR} AS agent_type,
+            {WORKFLOW_ID_EXPR} AS workflow_id
+        FROM raw_records,
+        LATERAL (
+            SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item
+        )
+        WHERE json_extract_string(json, '$.type') = 'user'
+        AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
+        AND json_extract_string(item, '$.type') = 'tool_result'")
+}
+```
+
+- [ ] **Step 4: Add `claude_sessions_sql`**
+
+This is the `register_sessions_view` body with two changes: a `'claude' AS harness` output column, and `WHERE harness = 'claude'` filters on both the outer `messages` scan and the `first_user_message` subquery (no-op today, required for PR 2 correctness):
+
+```rust
+/// The Claude `sessions` view body. Aggregates over the (possibly multi-provider)
+/// `messages` view, filtered to Claude rows so it never scoops up another harness's
+/// messages once `messages` becomes a UNION.
+pub fn claude_sessions_sql() -> String {
+    "SELECT
+            session_id,
+            COALESCE(
+                MAX(project) FILTER (WHERE NOT is_sidechain),
+                MAX(project)
+            ) AS project,
+            COALESCE(
+                MAX(source) FILTER (WHERE NOT is_sidechain),
+                MAX(source)
+            ) AS source,
+            'claude' AS harness,
+            MIN(timestamp) FILTER (WHERE NOT is_sidechain) AS started_at,
+            MAX(timestamp) FILTER (WHERE NOT is_sidechain) AS ended_at,
+            COUNT(*) FILTER (WHERE NOT is_sidechain) AS message_count,
+            CAST(COALESCE(SUM(tool_count) FILTER (WHERE NOT is_sidechain), 0) AS BIGINT) AS tool_call_count,
+            COUNT(*) FILTER (WHERE type = 'user' AND NOT is_sidechain) AS user_message_count,
+            COUNT(DISTINCT agent_id) AS subagent_count,
+            (SELECT text FROM messages m2
+             WHERE m2.session_id = m1.session_id
+             AND m2.harness = 'claude'
+             AND m2.type = 'user'
+             AND NOT m2.is_sidechain
+             AND m2.text IS NOT NULL
+             AND m2.text != ''
+             AND m2.text NOT LIKE '<%'
+             AND m2.text NOT LIKE 'Base directory for this skill%'
+             AND m2.text NOT LIKE '#%'
+             ORDER BY m2.timestamp LIMIT 1) AS first_user_message
+        FROM messages m1
+        WHERE harness = 'claude'
+        GROUP BY session_id".to_string()
+}
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cargo build`
+Expected: PASS. Warnings about the new functions being unused are expected — Task 3 wires them in.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views.rs
+git commit -m "refactor: extract Claude view bodies into functions, add harness column"
+```
+
+---
+
+## Task 3: Add the composer and rewire `register_views` through it
+
+**Files:**
+- Modify: `src/views.rs`
+- Modify: `src/claude_provider.rs`
+
+- [ ] **Step 1: Implement `ClaudeProvider::contribute_view_sql` and `prepare`**
+
+In `src/claude_provider.rs`, inside `impl TranscriptProvider for ClaudeProvider`, add (keep the existing `name`/`discover_files`/`register_views`/`list_projects`):
+
+```rust
+    fn prepare(&self, _conn: &Connection) -> Result<bool> {
+        // Claude's JSONL->raw_records sync happens in db::setup_connection /
+        // indexer; nothing extra to prepare here. Always active.
+        Ok(true)
+    }
+
+    fn contribute_view_sql(&self, view: crate::provider::View) -> Option<String> {
+        use crate::provider::View;
+        Some(match view {
+            View::Messages => crate::views::claude_messages_sql(),
+            View::ToolCalls => crate::views::claude_tool_calls_sql(),
+            View::ToolResults => crate::views::claude_tool_results_sql(),
+            View::Sessions => crate::views::claude_sessions_sql(),
+        })
+    }
+```
+
+Ensure `use crate::provider::View;` or the fully-qualified path resolves (the snippet uses the full path, so no new top-level import is strictly required).
+
+- [ ] **Step 2: Add `empty_view_sql` and `compose_views` to `views.rs`**
+
+Add to `src/views.rs`. `empty_view_sql` returns the empty body for one view (the existing `register_empty_views` bodies, each with `NULL::VARCHAR AS harness` added after `source`):
+
+```rust
+use crate::provider::{TranscriptProvider, View};
+
+/// The empty-view body (correct schema, zero rows) for one view. Used when no
+/// active provider contributes to that view.
+fn empty_view_sql(view: View) -> &'static str {
+    match view {
+        View::Messages => "SELECT
+            NULL::VARCHAR AS session_id,
+            NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
+            NULL::VARCHAR AS uuid,
+            NULL::VARCHAR AS parent_uuid,
+            NULL::VARCHAR AS type,
+            NULL::VARCHAR AS timestamp,
+            NULL::VARCHAR AS text,
+            CAST(0 AS BIGINT) AS tool_count,
+            NULL::VARCHAR AS model,
+            NULL::VARCHAR AS agent_id,
+            false AS is_sidechain,
+            NULL::VARCHAR AS agent_type,
+            NULL::VARCHAR AS workflow_id
+        WHERE 1=0",
+        View::ToolCalls => "SELECT
+            NULL::VARCHAR AS session_id,
+            NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
+            NULL::VARCHAR AS message_uuid,
+            NULL::VARCHAR AS tool_use_id,
+            NULL::VARCHAR AS name,
+            NULL::JSON AS input,
+            NULL::VARCHAR AS timestamp,
+            NULL::VARCHAR AS agent_id,
+            false AS is_sidechain,
+            NULL::VARCHAR AS agent_type,
+            NULL::VARCHAR AS workflow_id
+        WHERE 1=0",
+        View::ToolResults => "SELECT
+            NULL::VARCHAR AS session_id,
+            NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
+            NULL::VARCHAR AS tool_use_id,
+            false AS is_error,
+            NULL::VARCHAR AS content,
+            NULL::VARCHAR AS agent_id,
+            false AS is_sidechain,
+            NULL::VARCHAR AS agent_type,
+            NULL::VARCHAR AS workflow_id
+        WHERE 1=0",
+        View::Sessions => "SELECT
+            NULL::VARCHAR AS session_id,
+            NULL::VARCHAR AS project,
+            NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
+            NULL::VARCHAR AS started_at,
+            NULL::VARCHAR AS ended_at,
+            CAST(0 AS BIGINT) AS message_count,
+            CAST(0 AS BIGINT) AS tool_call_count,
+            CAST(0 AS BIGINT) AS user_message_count,
+            CAST(0 AS BIGINT) AS subagent_count,
+            NULL::VARCHAR AS first_user_message
+        WHERE 1=0",
+    }
+}
+
+/// Compose the four views from the active providers' contributions. Each
+/// contribution is wrapped in parens and `UNION ALL`ed. A view with no
+/// contributors falls back to the empty-view schema. Views are created in
+/// `View::ALL` order so `sessions` (which reads `messages`) comes last.
+pub fn compose_views(conn: &Connection, providers: &[&dyn TranscriptProvider]) -> Result<()> {
+    for view in View::ALL {
+        let parts: Vec<String> = providers
+            .iter()
+            .filter_map(|p| p.contribute_view_sql(view))
+            .map(|body| format!("({body})"))
+            .collect();
+        let body = if parts.is_empty() {
+            empty_view_sql(view).to_string()
+        } else {
+            parts.join("\nUNION ALL\n")
+        };
+        let sql = format!("CREATE OR REPLACE VIEW {} AS {body}", view.name());
+        conn.execute_batch(&sql)
+            .with_context(|| format!("Failed to create {} view", view.name()))?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Rewire `register_views` and `register_derived_views`, delete the old per-view + empty functions**
+
+Replace the bodies of `register_views` and `register_derived_views`, and delete `register_messages_view`, `register_tool_calls_view`, `register_tool_results_view`, `register_sessions_view`, and `register_empty_views` (their SQL now lives in the `claude_*_sql` / `empty_view_sql` functions):
+
+```rust
+/// Register all queryable views against the given JSONL transcript files.
+/// When `files` is empty, creates empty views with the correct schema.
+pub fn register_views(conn: &Connection, files: &[PathBuf]) -> Result<()> {
+    if files.is_empty() {
+        // No raw_records source; compose with no active providers -> empty views.
+        return compose_views(conn, &[]);
+    }
+    let file_list = build_file_list(files);
+    register_raw_view(conn, &file_list)?;
+    register_derived_views(conn)
+}
+
+/// Register the derived views over an existing `raw_records`. Composes from the
+/// Claude provider (the only provider that reads `raw_records`).
+pub fn register_derived_views(conn: &Connection) -> Result<()> {
+    let claude = crate::claude_provider::ClaudeProvider::new_with_base(std::path::PathBuf::new());
+    compose_views(conn, &[&claude])
+}
+```
+
+> Note: `contribute_view_sql` ignores the provider's source list (the bodies read `raw_records`), so the throwaway `new_with_base(PathBuf::new())` is safe and cheap here.
+
+- [ ] **Step 4: Run the full view test suite**
+
+Run: `cargo test --test views_test`
+Expected: PASS for all existing tests. The `harness` column is additive; tests selecting specific columns or `COUNT(*)` are unaffected. If any test asserts an exact column set (e.g. via `SELECT *` shape or a hardcoded column count), fix it in Task 5's test step — note the failure name and continue.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views.rs src/claude_provider.rs
+git commit -m "refactor: compose views from provider contributions via UNION ALL"
+```
+
+---
+
+## Task 4: Thread the provider collection through `db` and `main`
+
+**Files:**
+- Modify: `src/db.rs:40-61`
+- Modify: `src/main.rs:209` and `src/main.rs:295`
+
+- [ ] **Step 1: Update `setup_connection` to accept providers and compose from the active set**
+
+In `src/db.rs`, change `setup_connection` to take the provider list, run `prepare` on each, and compose from the active providers. Keep the indexer sync exactly as-is (Claude machinery):
+
+```rust
+use crate::provider::TranscriptProvider;
+
+pub fn setup_connection(
+    providers: &[Box<dyn TranscriptProvider>],
+    sources: &[(String, std::path::PathBuf)],
+    options: &DbOptions,
+    scope: SyncScope,
+) -> Result<DbSetup> {
+    let cache_dir = cache::cache_dir()?;
+    let force_rebuild = options.sync_mode == SyncMode::Force;
+    let conn = cache::open(&cache_dir, force_rebuild)?;
+
+    let result = indexer::sync_sources(&conn, sources, options.sync_mode, scope, &cache_dir)?;
+    let file_count = result.stats.added + result.stats.changed;
+
+    // Ask each provider to prepare and report whether it is active, then compose.
+    let mut active: Vec<&dyn TranscriptProvider> = Vec::new();
+    for p in providers {
+        if p.prepare(&conn)? {
+            active.push(p.as_ref());
+        }
+    }
+    views::compose_views(&conn, &active)?;
+
+    Ok(DbSetup {
+        conn,
+        file_count,
+        total_files: result.stats.total,
+        skipped: result.skipped,
+        lock_busy: result.lock_busy,
+    })
+}
+```
+
+- [ ] **Step 2: Build the provider list in `main.rs` and pass it**
+
+In `src/main.rs`, the provider is already constructed at line 209 (`let provider = ClaudeProvider::new()?;`) and used for scope logic. Keep that. Add a boxed provider collection just before the `setup_connection` call (line 295) and pass it. Change:
+
+```rust
+    let db_setup = db::setup_connection(&sources, &options, sync_scope)?;
+```
+
+to:
+
+```rust
+    let providers: Vec<Box<dyn cq::provider::TranscriptProvider>> =
+        vec![Box::new(cq::claude_provider::ClaudeProvider::new()?)];
+    let db_setup = db::setup_connection(&providers, &sources, &options, sync_scope)?;
+```
+
+> The `sources` vec (line 275) is still derived from the scope provider for the indexer; leave it. This PR keeps two references to Claude (the scope `provider` and the boxed `providers[0]`); consolidating them is out of scope and a candidate for a later cleanup.
+
+- [ ] **Step 3: Build and run the full suite**
+
+Run: `cargo build && cargo test`
+Expected: PASS (build clean, all tests green).
+
+- [ ] **Step 4: Smoke-test against real data (no behavior change)**
+
+Run: `cargo run -- sessions --limit 3` and `cargo run -- sql "SELECT DISTINCT harness FROM sessions"`
+Expected: the first prints sessions as before; the second prints a single row `claude`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db.rs src/main.rs
+git commit -m "refactor: thread provider collection through setup_connection"
+```
+
+---
+
+## Task 5: Add `harness` regression tests and fix any broken column-set assertions
+
+**Files:**
+- Modify: `tests/views_test.rs`
+
+- [ ] **Step 1: Add a test that every view exposes `harness = 'claude'`**
+
+Append to `tests/views_test.rs` (uses the existing `setup_db` helper and the `simple_session.jsonl` fixture already used by the first test):
+
+```rust
+#[test]
+fn views_expose_claude_harness() {
+    let conn = setup_db("simple_session.jsonl");
+    for view in ["messages", "tool_calls", "tool_results", "sessions"] {
+        // Every non-empty view's rows are tagged harness='claude'.
+        let distinct: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM (SELECT DISTINCT harness FROM {view} WHERE harness IS NOT NULL)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(distinct <= 1, "{view} should have at most one harness value");
+        let claude: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {view} WHERE harness = 'claude'"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let total: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {view}"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(claude, total, "all {view} rows should be harness='claude'");
+    }
+}
+
+#[test]
+fn empty_views_have_harness_column() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE file_registry (
+            file_path TEXT PRIMARY KEY, mtime_ns BIGINT, file_size BIGINT,
+            cwd TEXT, agent_type TEXT, source TEXT,
+            indexed_at TIMESTAMP DEFAULT current_timestamp
+        )",
+    )
+    .unwrap();
+    cq::views::register_views(&conn, &[]).unwrap();
+    // Selecting harness from each empty view must not error (column exists).
+    for view in ["messages", "tool_calls", "tool_results", "sessions"] {
+        let n: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {view} WHERE harness IS NULL"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "{view} should be empty");
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `cargo test --test views_test views_expose_claude_harness empty_views_have_harness_column`
+Expected: PASS.
+
+- [ ] **Step 3: Run the entire view suite and fix any column-set regressions**
+
+Run: `cargo test --test views_test`
+Expected: PASS. If a pre-existing test fails because it asserted an exact column count or `SELECT *` row shape, update that assertion to include the new `harness` column (placed after `source`). Do not change any non-harness expected values.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/views_test.rs
+git commit -m "test: assert harness column across all four views"
+```
+
+---
+
+## Task 6: Update docs for the new `harness` column
+
+**Files:**
+- Modify: `src/commands/schema.rs`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add `harness` to the schema command's column docs**
+
+Open `src/commands/schema.rs`. For each of the four views' documented column lists, add a `harness` entry immediately after `source`, described as: `harness — the tool that produced the transcript (claude, opencode)`. Match the file's existing formatting for column entries exactly (find the `source` line in each view's block and mirror its style).
+
+- [ ] **Step 2: Verify the schema command renders**
+
+Run: `cargo run -- schema` and `cargo run -- schema --examples`
+Expected: each view lists a `harness` column after `source`; no formatting breakage.
+
+- [ ] **Step 3: Update README and CLAUDE.md view tables**
+
+In `README.md` and `CLAUDE.md`, find the view/column reference tables and add `harness` after `source` with the same description as Step 1. (In `CLAUDE.md`, the relevant spot is the views/architecture description; keep edits minimal and consistent with surrounding style.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/schema.rs README.md CLAUDE.md
+git commit -m "docs: document the harness column on all views"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Full clean build + test**
+
+Run: `cargo build && cargo test`
+Expected: clean build, **all** tests green (unit + `views_test` + `integration_test`).
+
+- [ ] **Step 2: Confirm no behavior change for Claude**
+
+Run: `cargo run -- sessions --limit 5`, `cargo run -- tools --limit 5`, `cargo run -- messages --limit 5`
+Expected: identical output shape to `main` (plus the views now carry a `harness` column visible via `--fields harness` or `sql`).
+
+- [ ] **Step 3: Confirm the seam is real**
+
+Run: `cargo run -- sql "SELECT harness, COUNT(*) FROM messages GROUP BY harness"`
+Expected: a single `claude` row. (PR 2 will add an `opencode` row through the same composer with zero changes to Task 1–6 code.)
+
+---
+
+## Self-Review
+
+**Spec coverage** (against ADR 0001 + findings "Design resolutions"):
+- Provider collection in `main.rs` instead of hardcoded `ClaudeProvider::new()` → Task 4. ✓
+- Two-phase trait (`prepare` / `contribute_view_sql`) → Task 1. ✓
+- `UNION ALL` view composer → Task 3 (`compose_views`). ✓
+- New `harness` column on all four Claude views → Tasks 2, 3, 5, 6. ✓
+- Claude-specific scope/`--source` plumbing stays off the trait → not moved (Task 4 note). ✓
+- Empty-view fallback preserved → Task 3 (`empty_view_sql`). ✓
+- Tests stay green / additive change → Tasks 3–5. ✓
+- Docs-in-sync → Task 6. ✓
+- Out of scope (correctly deferred to PR 2): `OpenCodeProvider`, `ATTACH`, `INSTALL sqlite`, cost/token columns, schema-drift SQL refresh.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N" — all SQL bodies and Rust are spelled out. ✓
+
+**Type consistency:** `View` enum + `View::ALL`/`View::name()` (Task 1) used identically in `contribute_view_sql` (Tasks 1, 3), `compose_views` and `empty_view_sql` (Task 3). `compose_views(conn, &[&dyn TranscriptProvider])` signature matches its callers in `register_derived_views` (Task 3) and `setup_connection` (Task 4). `claude_*_sql()` names match between definition (Task 2) and use (Task 3). `setup_connection`'s new `providers` first-arg matches the `main.rs` call site (Task 4). ✓

--- a/src/claude_provider.rs
+++ b/src/claude_provider.rs
@@ -180,6 +180,22 @@ impl TranscriptProvider for ClaudeProvider {
         projects.sort_by(|a, b| b.file_count.cmp(&a.file_count));
         Ok(projects)
     }
+
+    fn prepare(&self, _conn: &Connection) -> Result<bool> {
+        // Claude's JSONL->raw_records sync happens in db::setup_connection /
+        // indexer; nothing extra to prepare here. Always active.
+        Ok(true)
+    }
+
+    fn contribute_view_sql(&self, view: crate::provider::View) -> Option<String> {
+        use crate::provider::View;
+        Some(match view {
+            View::Messages => crate::views::claude_messages_sql(),
+            View::ToolCalls => crate::views::claude_tool_calls_sql(),
+            View::ToolResults => crate::views::claude_tool_results_sql(),
+            View::Sessions => crate::views::claude_sessions_sql(),
+        })
+    }
 }
 
 /// Recursively collect indexable `.jsonl` files under `dir`, excluding

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -30,6 +30,7 @@ const MESSAGES_SCHEMA: &str = r#"messages
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name (directory containing the JSONL file)
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   uuid                VARCHAR   Message UUID
   parent_uuid         VARCHAR   Parent message UUID
   type                VARCHAR   'user' or 'assistant'
@@ -47,6 +48,7 @@ const TOOL_CALLS_SCHEMA: &str = r#"tool_calls
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   message_uuid        VARCHAR   UUID of the containing assistant message
   tool_use_id         VARCHAR   Unique tool use ID (matches tool_results.tool_use_id)
   name                VARCHAR   Tool name (e.g. 'Bash', 'Read', 'Edit', 'Skill')
@@ -65,6 +67,7 @@ const TOOL_RESULTS_SCHEMA: &str = r#"tool_results
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   tool_use_id         VARCHAR   Matches tool_calls.tool_use_id
   is_error            BOOLEAN   true if the tool call returned an error
   content             VARCHAR   Tool result content (text)
@@ -78,6 +81,7 @@ const SESSIONS_SCHEMA: &str = r#"sessions
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   started_at          VARCHAR   Timestamp of first message
   ended_at            VARCHAR   Timestamp of last message
   message_count       BIGINT    Total messages in session
@@ -152,6 +156,7 @@ messages
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name (directory containing the JSONL file)
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   uuid                VARCHAR   Message UUID
   parent_uuid         VARCHAR   Parent message UUID
   type                VARCHAR   'user' or 'assistant'
@@ -169,6 +174,7 @@ tool_calls
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   message_uuid        VARCHAR   UUID of the containing assistant message
   tool_use_id         VARCHAR   Unique tool use ID (matches tool_results.tool_use_id)
   name                VARCHAR   Tool name (e.g. 'Bash', 'Read', 'Edit', 'Skill')
@@ -187,6 +193,7 @@ tool_results
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   tool_use_id         VARCHAR   Matches tool_calls.tool_use_id
   is_error            BOOLEAN   true if the tool call returned an error
   content             VARCHAR   Tool result content (text)
@@ -200,6 +207,7 @@ sessions
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
+  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
   started_at          VARCHAR   Timestamp of first message
   ended_at            VARCHAR   Timestamp of last message
   message_count       BIGINT    Total messages in session

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,7 @@ use duckdb::Connection;
 use crate::cache;
 use crate::indexer;
 use crate::views;
+use crate::provider::TranscriptProvider;
 use crate::sync_scope::SyncScope;
 
 pub struct DbSetup {
@@ -38,6 +39,7 @@ impl Default for DbOptions {
 ///
 /// Uses the persistent cache for fast incremental startup.
 pub fn setup_connection(
+    providers: &[Box<dyn TranscriptProvider>],
     sources: &[(String, std::path::PathBuf)],
     options: &DbOptions,
     scope: SyncScope,
@@ -49,7 +51,14 @@ pub fn setup_connection(
     let result = indexer::sync_sources(&conn, sources, options.sync_mode, scope, &cache_dir)?;
     let file_count = result.stats.added + result.stats.changed;
 
-    views::register_derived_views(&conn)?;
+    // Ask each provider to prepare and report whether it is active, then compose.
+    let mut active: Vec<&dyn TranscriptProvider> = Vec::new();
+    for p in providers {
+        if p.prepare(&conn)? {
+            active.push(p.as_ref());
+        }
+    }
+    views::compose_views(&conn, &active)?;
 
     Ok(DbSetup {
         conn,

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,9 @@ fn main() -> Result<()> {
     };
 
     let start = std::time::Instant::now();
-    let db_setup = db::setup_connection(&sources, &options, sync_scope)?;
+    let providers: Vec<Box<dyn cq::provider::TranscriptProvider>> =
+        vec![Box::new(cq::claude_provider::ClaudeProvider::new()?)];
+    let db_setup = db::setup_connection(&providers, &sources, &options, sync_scope)?;
     let elapsed = start.elapsed();
     if db_setup.lock_busy {
         eprintln!("index busy, using cached data (re-run with --reindex to force)");

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use duckdb::Connection;
 use std::path::PathBuf;
+use crate::provider::{TranscriptProvider, View};
 
 /// SQL expression to get the project path. Uses cwd from file_registry if
 /// available, falls back to decoding the directory name from source_file.
@@ -43,25 +44,21 @@ const SOURCE_EXPR: &str =
 /// don't error.
 pub fn register_views(conn: &Connection, files: &[PathBuf]) -> Result<()> {
     if files.is_empty() {
-        return register_empty_views(conn);
+        // No raw_records source; compose with no active providers -> empty views.
+        return compose_views(conn, &[]);
     }
 
     let file_list = build_file_list(files);
     register_raw_view(conn, &file_list)?;
-    register_derived_views(conn)?;
-
-    Ok(())
+    register_derived_views(conn)
 }
 
-/// Register only the derived views (messages, tool_calls, tool_results, sessions).
-/// Assumes raw_records already exists (either as a view from read_json or as a
-/// persistent table from the cache).
+/// Register the derived views over an existing `raw_records`. Composes from the
+/// Claude provider (the only provider that reads `raw_records`).
 pub fn register_derived_views(conn: &Connection) -> Result<()> {
-    register_messages_view(conn)?;
-    register_tool_calls_view(conn)?;
-    register_tool_results_view(conn)?;
-    register_sessions_view(conn)?;
-    Ok(())
+    let claude = crate::claude_provider::ClaudeProvider::new_with_base(std::path::PathBuf::new());
+    let providers: [&dyn TranscriptProvider; 1] = [&claude];
+    compose_views(conn, &providers)
 }
 
 /// Build a DuckDB list literal from file paths: ['path1', 'path2', ...]
@@ -231,184 +228,15 @@ pub fn claude_sessions_sql() -> String {
         GROUP BY session_id".to_string()
 }
 
-/// Create the messages view.
-///
-/// User messages can have string content (human text) or array content (tool results).
-/// Assistant messages always have array content (text blocks + tool_use blocks).
-///
-/// We use UNION ALL to handle both cases separately, avoiding DuckDB's eagerness
-/// to evaluate CAST(content AS JSON[]) even inside a CASE WHEN branch where
-/// content is a string.
-fn register_messages_view(conn: &Connection) -> Result<()> {
-    let sql = format!("CREATE OR REPLACE VIEW messages AS
-        WITH string_msgs AS (
-            SELECT
-                json_extract_string(json, '$.sessionId') AS session_id,
-                {PROJECT_EXPR} AS project,
-                {SOURCE_EXPR} AS source,
-                json_extract_string(json, '$.uuid') AS uuid,
-                json_extract_string(json, '$.parentUuid') AS parent_uuid,
-                json_extract_string(json, '$.type') AS type,
-                json_extract_string(json, '$.timestamp') AS timestamp,
-                json_extract_string(json, '$.message.content') AS text,
-                CAST(0 AS BIGINT) AS tool_count,
-                json_extract_string(json, '$.message.model') AS model,
-                {AGENT_ID_EXPR} AS agent_id,
-                {IS_SIDECHAIN_EXPR} AS is_sidechain,
-                {AGENT_TYPE_EXPR} AS agent_type,
-                {WORKFLOW_ID_EXPR} AS workflow_id
-            FROM raw_records
-            WHERE json_extract_string(json, '$.type') IN ('user', 'assistant')
-            AND json_type(json_extract(json, '$.message.content')) = 'VARCHAR'
-        ),
-        array_msgs AS (
-            SELECT
-                json_extract_string(json, '$.sessionId') AS session_id,
-                {PROJECT_EXPR} AS project,
-                {SOURCE_EXPR} AS source,
-                json_extract_string(json, '$.uuid') AS uuid,
-                json_extract_string(json, '$.parentUuid') AS parent_uuid,
-                json_extract_string(json, '$.type') AS type,
-                json_extract_string(json, '$.timestamp') AS timestamp,
-                (SELECT json_extract_string(item, '$.text')
-                 FROM (SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item)
-                 WHERE json_extract_string(item, '$.type') = 'text'
-                 LIMIT 1) AS text,
-                CASE WHEN json_extract_string(json, '$.type') = 'assistant' THEN
-                    (SELECT COUNT(*)
-                     FROM (SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item)
-                     WHERE json_extract_string(item, '$.type') = 'tool_use')
-                ELSE CAST(0 AS BIGINT)
-                END AS tool_count,
-                json_extract_string(json, '$.message.model') AS model,
-                {AGENT_ID_EXPR} AS agent_id,
-                {IS_SIDECHAIN_EXPR} AS is_sidechain,
-                {AGENT_TYPE_EXPR} AS agent_type,
-                {WORKFLOW_ID_EXPR} AS workflow_id
-            FROM raw_records
-            WHERE json_extract_string(json, '$.type') IN ('user', 'assistant')
-            AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
-        )
-        SELECT * FROM string_msgs
-        UNION ALL
-        SELECT * FROM array_msgs");
-    conn.execute_batch(&sql)
-        .context("Failed to create messages view")?;
-    Ok(())
-}
-
-/// Create the tool_calls view.
-///
-/// Extracts one row per tool_use content block from assistant messages.
-/// Uses LATERAL UNNEST to flatten the content array, then filters for tool_use type.
-fn register_tool_calls_view(conn: &Connection) -> Result<()> {
-    let sql = format!("CREATE OR REPLACE VIEW tool_calls AS
-        SELECT
-            json_extract_string(json, '$.sessionId') AS session_id,
-            {PROJECT_EXPR} AS project,
-            {SOURCE_EXPR} AS source,
-            json_extract_string(json, '$.uuid') AS message_uuid,
-            json_extract_string(item, '$.id') AS tool_use_id,
-            json_extract_string(item, '$.name') AS name,
-            json_extract(item, '$.input') AS input,
-            json_extract_string(json, '$.timestamp') AS timestamp,
-            {AGENT_ID_EXPR} AS agent_id,
-            {IS_SIDECHAIN_EXPR} AS is_sidechain,
-            {AGENT_TYPE_EXPR} AS agent_type,
-            {WORKFLOW_ID_EXPR} AS workflow_id
-        FROM raw_records,
-        LATERAL (
-            SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item
-        )
-        WHERE json_extract_string(json, '$.type') = 'assistant'
-        AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
-        AND json_extract_string(item, '$.type') = 'tool_use'");
-    conn.execute_batch(&sql)
-        .context("Failed to create tool_calls view")?;
-    Ok(())
-}
-
-/// Create the tool_results view.
-///
-/// Extracts one row per tool_result content block from user messages that have
-/// array content (i.e. messages carrying tool results back from tool execution).
-fn register_tool_results_view(conn: &Connection) -> Result<()> {
-    let sql = format!("CREATE OR REPLACE VIEW tool_results AS
-        SELECT
-            json_extract_string(json, '$.sessionId') AS session_id,
-            {PROJECT_EXPR} AS project,
-            {SOURCE_EXPR} AS source,
-            json_extract_string(item, '$.tool_use_id') AS tool_use_id,
-            COALESCE(CAST(json_extract(item, '$.is_error') AS BOOLEAN), false) AS is_error,
-            json_extract_string(item, '$.content') AS content,
-            {AGENT_ID_EXPR} AS agent_id,
-            {IS_SIDECHAIN_EXPR} AS is_sidechain,
-            {AGENT_TYPE_EXPR} AS agent_type,
-            {WORKFLOW_ID_EXPR} AS workflow_id
-        FROM raw_records,
-        LATERAL (
-            SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item
-        )
-        WHERE json_extract_string(json, '$.type') = 'user'
-        AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
-        AND json_extract_string(item, '$.type') = 'tool_result'");
-    conn.execute_batch(&sql)
-        .context("Failed to create tool_results view")?;
-    Ok(())
-}
-
-/// Create the sessions view.
-///
-/// Aggregates from the messages view to provide session-level metrics.
-/// Counts (message_count, tool_call_count, user_message_count) include only
-/// main-loop rows (is_sidechain = false). subagent_count is the number of
-/// distinct subagent IDs seen in the session (NULL agent_id for main-loop rows
-/// is ignored by COUNT(DISTINCT)).
-fn register_sessions_view(conn: &Connection) -> Result<()> {
-    let sql = "CREATE OR REPLACE VIEW sessions AS
-        SELECT
-            session_id,
-            COALESCE(
-                MAX(project) FILTER (WHERE NOT is_sidechain),
-                MAX(project)
-            ) AS project,
-            COALESCE(
-                MAX(source) FILTER (WHERE NOT is_sidechain),
-                MAX(source)
-            ) AS source,
-            MIN(timestamp) FILTER (WHERE NOT is_sidechain) AS started_at,
-            MAX(timestamp) FILTER (WHERE NOT is_sidechain) AS ended_at,
-            COUNT(*) FILTER (WHERE NOT is_sidechain) AS message_count,
-            CAST(COALESCE(SUM(tool_count) FILTER (WHERE NOT is_sidechain), 0) AS BIGINT) AS tool_call_count,
-            COUNT(*) FILTER (WHERE type = 'user' AND NOT is_sidechain) AS user_message_count,
-            COUNT(DISTINCT agent_id) AS subagent_count,
-            (SELECT text FROM messages m2
-             WHERE m2.session_id = m1.session_id
-             AND m2.type = 'user'
-             AND NOT m2.is_sidechain
-             AND m2.text IS NOT NULL
-             AND m2.text != ''
-             AND m2.text NOT LIKE '<%'
-             AND m2.text NOT LIKE 'Base directory for this skill%'
-             AND m2.text NOT LIKE '#%'
-             ORDER BY m2.timestamp LIMIT 1) AS first_user_message
-        FROM messages m1
-        GROUP BY session_id";
-    conn.execute_batch(sql)
-        .context("Failed to create sessions view")?;
-    Ok(())
-}
-
-/// Register empty views when no files are provided.
-/// Uses WHERE 1=0 against a VALUES clause so queries return 0 rows
-/// without erroring on missing tables.
-fn register_empty_views(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
-        "CREATE OR REPLACE VIEW messages AS
-        SELECT
+/// The empty-view body (correct schema, zero rows) for one view. Used when no
+/// active provider contributes to that view.
+fn empty_view_sql(view: View) -> &'static str {
+    match view {
+        View::Messages => "SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
             NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
             NULL::VARCHAR AS uuid,
             NULL::VARCHAR AS parent_uuid,
             NULL::VARCHAR AS type,
@@ -420,15 +248,12 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
             false AS is_sidechain,
             NULL::VARCHAR AS agent_type,
             NULL::VARCHAR AS workflow_id
-        WHERE 1=0"
-    ).context("Failed to create empty messages view")?;
-
-    conn.execute_batch(
-        "CREATE OR REPLACE VIEW tool_calls AS
-        SELECT
+        WHERE 1=0",
+        View::ToolCalls => "SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
             NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
             NULL::VARCHAR AS message_uuid,
             NULL::VARCHAR AS tool_use_id,
             NULL::VARCHAR AS name,
@@ -438,15 +263,12 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
             false AS is_sidechain,
             NULL::VARCHAR AS agent_type,
             NULL::VARCHAR AS workflow_id
-        WHERE 1=0"
-    ).context("Failed to create empty tool_calls view")?;
-
-    conn.execute_batch(
-        "CREATE OR REPLACE VIEW tool_results AS
-        SELECT
+        WHERE 1=0",
+        View::ToolResults => "SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
             NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
             NULL::VARCHAR AS tool_use_id,
             false AS is_error,
             NULL::VARCHAR AS content,
@@ -454,15 +276,12 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
             false AS is_sidechain,
             NULL::VARCHAR AS agent_type,
             NULL::VARCHAR AS workflow_id
-        WHERE 1=0"
-    ).context("Failed to create empty tool_results view")?;
-
-    conn.execute_batch(
-        "CREATE OR REPLACE VIEW sessions AS
-        SELECT
+        WHERE 1=0",
+        View::Sessions => "SELECT
             NULL::VARCHAR AS session_id,
             NULL::VARCHAR AS project,
             NULL::VARCHAR AS source,
+            NULL::VARCHAR AS harness,
             NULL::VARCHAR AS started_at,
             NULL::VARCHAR AS ended_at,
             CAST(0 AS BIGINT) AS message_count,
@@ -470,8 +289,29 @@ fn register_empty_views(conn: &Connection) -> Result<()> {
             CAST(0 AS BIGINT) AS user_message_count,
             CAST(0 AS BIGINT) AS subagent_count,
             NULL::VARCHAR AS first_user_message
-        WHERE 1=0"
-    ).context("Failed to create empty sessions view")?;
+        WHERE 1=0",
+    }
+}
 
+/// Compose the four views from the active providers' contributions. Each
+/// contribution is wrapped in parens and `UNION ALL`ed. A view with no
+/// contributors falls back to the empty-view schema. Views are created in
+/// `View::ALL` order so `sessions` (which reads `messages`) comes last.
+pub fn compose_views(conn: &Connection, providers: &[&dyn TranscriptProvider]) -> Result<()> {
+    for view in View::ALL {
+        let parts: Vec<String> = providers
+            .iter()
+            .filter_map(|p| p.contribute_view_sql(view))
+            .map(|body| format!("({body})"))
+            .collect();
+        let body = if parts.is_empty() {
+            empty_view_sql(view).to_string()
+        } else {
+            parts.join("\nUNION ALL\n")
+        };
+        let sql = format!("CREATE OR REPLACE VIEW {} AS {body}", view.name());
+        conn.execute_batch(&sql)
+            .with_context(|| format!("Failed to create {} view", view.name()))?;
+    }
     Ok(())
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -89,6 +89,148 @@ fn register_raw_view(conn: &Connection, file_list: &str) -> Result<()> {
     Ok(())
 }
 
+/// The Claude `messages` view body (SELECT only, no CREATE VIEW wrapper).
+pub fn claude_messages_sql() -> String {
+    format!("WITH string_msgs AS (
+            SELECT
+                json_extract_string(json, '$.sessionId') AS session_id,
+                {PROJECT_EXPR} AS project,
+                {SOURCE_EXPR} AS source,
+                'claude' AS harness,
+                json_extract_string(json, '$.uuid') AS uuid,
+                json_extract_string(json, '$.parentUuid') AS parent_uuid,
+                json_extract_string(json, '$.type') AS type,
+                json_extract_string(json, '$.timestamp') AS timestamp,
+                json_extract_string(json, '$.message.content') AS text,
+                CAST(0 AS BIGINT) AS tool_count,
+                json_extract_string(json, '$.message.model') AS model,
+                {AGENT_ID_EXPR} AS agent_id,
+                {IS_SIDECHAIN_EXPR} AS is_sidechain,
+                {AGENT_TYPE_EXPR} AS agent_type,
+                {WORKFLOW_ID_EXPR} AS workflow_id
+            FROM raw_records
+            WHERE json_extract_string(json, '$.type') IN ('user', 'assistant')
+            AND json_type(json_extract(json, '$.message.content')) = 'VARCHAR'
+        ),
+        array_msgs AS (
+            SELECT
+                json_extract_string(json, '$.sessionId') AS session_id,
+                {PROJECT_EXPR} AS project,
+                {SOURCE_EXPR} AS source,
+                'claude' AS harness,
+                json_extract_string(json, '$.uuid') AS uuid,
+                json_extract_string(json, '$.parentUuid') AS parent_uuid,
+                json_extract_string(json, '$.type') AS type,
+                json_extract_string(json, '$.timestamp') AS timestamp,
+                (SELECT json_extract_string(item, '$.text')
+                 FROM (SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item)
+                 WHERE json_extract_string(item, '$.type') = 'text'
+                 LIMIT 1) AS text,
+                CASE WHEN json_extract_string(json, '$.type') = 'assistant' THEN
+                    (SELECT COUNT(*)
+                     FROM (SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item)
+                     WHERE json_extract_string(item, '$.type') = 'tool_use')
+                ELSE CAST(0 AS BIGINT)
+                END AS tool_count,
+                json_extract_string(json, '$.message.model') AS model,
+                {AGENT_ID_EXPR} AS agent_id,
+                {IS_SIDECHAIN_EXPR} AS is_sidechain,
+                {AGENT_TYPE_EXPR} AS agent_type,
+                {WORKFLOW_ID_EXPR} AS workflow_id
+            FROM raw_records
+            WHERE json_extract_string(json, '$.type') IN ('user', 'assistant')
+            AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
+        )
+        SELECT * FROM string_msgs
+        UNION ALL
+        SELECT * FROM array_msgs")
+}
+
+/// The Claude `tool_calls` view body.
+pub fn claude_tool_calls_sql() -> String {
+    format!("SELECT
+            json_extract_string(json, '$.sessionId') AS session_id,
+            {PROJECT_EXPR} AS project,
+            {SOURCE_EXPR} AS source,
+            'claude' AS harness,
+            json_extract_string(json, '$.uuid') AS message_uuid,
+            json_extract_string(item, '$.id') AS tool_use_id,
+            json_extract_string(item, '$.name') AS name,
+            json_extract(item, '$.input') AS input,
+            json_extract_string(json, '$.timestamp') AS timestamp,
+            {AGENT_ID_EXPR} AS agent_id,
+            {IS_SIDECHAIN_EXPR} AS is_sidechain,
+            {AGENT_TYPE_EXPR} AS agent_type,
+            {WORKFLOW_ID_EXPR} AS workflow_id
+        FROM raw_records,
+        LATERAL (
+            SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item
+        )
+        WHERE json_extract_string(json, '$.type') = 'assistant'
+        AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
+        AND json_extract_string(item, '$.type') = 'tool_use'")
+}
+
+/// The Claude `tool_results` view body.
+pub fn claude_tool_results_sql() -> String {
+    format!("SELECT
+            json_extract_string(json, '$.sessionId') AS session_id,
+            {PROJECT_EXPR} AS project,
+            {SOURCE_EXPR} AS source,
+            'claude' AS harness,
+            json_extract_string(item, '$.tool_use_id') AS tool_use_id,
+            COALESCE(CAST(json_extract(item, '$.is_error') AS BOOLEAN), false) AS is_error,
+            json_extract_string(item, '$.content') AS content,
+            {AGENT_ID_EXPR} AS agent_id,
+            {IS_SIDECHAIN_EXPR} AS is_sidechain,
+            {AGENT_TYPE_EXPR} AS agent_type,
+            {WORKFLOW_ID_EXPR} AS workflow_id
+        FROM raw_records,
+        LATERAL (
+            SELECT UNNEST(CAST(json_extract(json, '$.message.content') AS JSON[])) AS item
+        )
+        WHERE json_extract_string(json, '$.type') = 'user'
+        AND json_type(json_extract(json, '$.message.content')) = 'ARRAY'
+        AND json_extract_string(item, '$.type') = 'tool_result'")
+}
+
+/// The Claude `sessions` view body. Aggregates over the (possibly multi-provider)
+/// `messages` view, filtered to Claude rows so it never scoops up another harness's
+/// messages once `messages` becomes a UNION.
+pub fn claude_sessions_sql() -> String {
+    "SELECT
+            session_id,
+            COALESCE(
+                MAX(project) FILTER (WHERE NOT is_sidechain),
+                MAX(project)
+            ) AS project,
+            COALESCE(
+                MAX(source) FILTER (WHERE NOT is_sidechain),
+                MAX(source)
+            ) AS source,
+            'claude' AS harness,
+            MIN(timestamp) FILTER (WHERE NOT is_sidechain) AS started_at,
+            MAX(timestamp) FILTER (WHERE NOT is_sidechain) AS ended_at,
+            COUNT(*) FILTER (WHERE NOT is_sidechain) AS message_count,
+            CAST(COALESCE(SUM(tool_count) FILTER (WHERE NOT is_sidechain), 0) AS BIGINT) AS tool_call_count,
+            COUNT(*) FILTER (WHERE type = 'user' AND NOT is_sidechain) AS user_message_count,
+            COUNT(DISTINCT agent_id) AS subagent_count,
+            (SELECT text FROM messages m2
+             WHERE m2.session_id = m1.session_id
+             AND m2.harness = 'claude'
+             AND m2.type = 'user'
+             AND NOT m2.is_sidechain
+             AND m2.text IS NOT NULL
+             AND m2.text != ''
+             AND m2.text NOT LIKE '<%'
+             AND m2.text NOT LIKE 'Base directory for this skill%'
+             AND m2.text NOT LIKE '#%'
+             ORDER BY m2.timestamp LIMIT 1) AS first_user_message
+        FROM messages m1
+        WHERE harness = 'claude'
+        GROUP BY session_id".to_string()
+}
+
 /// Create the messages view.
 ///
 /// User messages can have string content (human text) or array content (tool results).

--- a/tests/views_test.rs
+++ b/tests/views_test.rs
@@ -729,3 +729,51 @@ fn empty_files_no_error() {
         .unwrap();
     assert_eq!(count, 0);
 }
+
+#[test]
+fn views_expose_claude_harness() {
+    let conn = setup_db("simple_session.jsonl");
+    for view in ["messages", "tool_calls", "tool_results", "sessions"] {
+        // Every non-empty view's rows are tagged harness='claude'.
+        let distinct: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM (SELECT DISTINCT harness FROM {view} WHERE harness IS NOT NULL)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(distinct <= 1, "{view} should have at most one harness value");
+        let claude: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {view} WHERE harness = 'claude'"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let total: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {view}"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(claude, total, "all {view} rows should be harness='claude'");
+    }
+}
+
+#[test]
+fn empty_views_have_harness_column() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE file_registry (
+            file_path TEXT PRIMARY KEY, mtime_ns BIGINT, file_size BIGINT,
+            cwd TEXT, agent_type TEXT, source TEXT,
+            indexed_at TIMESTAMP DEFAULT current_timestamp
+        )",
+    )
+    .unwrap();
+    cq::views::register_views(&conn, &[]).unwrap();
+    // Selecting harness from each empty view must not error (column exists).
+    for view in ["messages", "tool_calls", "tool_results", "sessions"] {
+        let n: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {view} WHERE harness IS NULL"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(n, 0, "{view} should be empty");
+    }
+}


### PR DESCRIPTION
## Summary

- The four views (`messages`, `tool_calls`, `tool_results`, `sessions`) are now composed from per-provider SQL contributions and `UNION ALL`ed together, rather than hardcoded over `raw_records`. The `TranscriptProvider` trait grows the seam that makes this work: `prepare(conn) -> bool` (is this provider active?) and `contribute_view_sql(view)` (a SELECT body).
- Adds a `harness` column to all four views, `'claude'` for every row today. It's a separate dimension from the existing within-Claude `--source` (main + cenv envs). The Harness / Provider / Source glossary is in `CONTEXT.md`.
- Pure refactor, no behavior change for Claude: `ClaudeProvider` is the only provider, always active, and its view bodies are the same SQL as before. This is the backbone for reading other harnesses without touching the Claude path. opencode is next, as a live-`ATTACH`ed provider that plugs into this seam.

The design behind it is in `docs/adr/0001-opencode-via-live-attach.md` and `CONTEXT.md`; the full plan for this PR and the opencode findings are under `docs/`.

## Test plan

- `cargo test` is green; added two regression tests asserting the `harness` column across all four views.
- End to end: `cq sql "SELECT harness, COUNT(*) FROM messages GROUP BY harness"` returns a single `claude` row.
- `cq sessions` output is unchanged.
