### PR TITLE
Add CI and release build workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref so pushes don't pile up.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0 # incremental builds don't help CI and bloat the cache
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Shared with clippy so the expensive bundled-DuckDB compile is cached
+          # once and reused across both jobs.
+          shared-key: build
+      - run: cargo test --locked
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: build
+      - run: cargo clippy --locked --all-targets -- -D warnings
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+# Cut a release by pushing a version tag, e.g.:
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# This builds cq on each target's native runner (no cross-compiling) because the
+# duckdb dependency bundles DuckDB's C++ source, and compiling that for a foreign
+# target is far more trouble than just using the matching runner.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-14
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package archive
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          staging="cq-${version}-${{ matrix.target }}"
+          mkdir "$staging"
+          cp "target/${{ matrix.target }}/release/cq" "$staging/"
+          cp README.md LICENSE "$staging/"
+          tar czf "${staging}.tar.gz" "$staging"
+          echo "ASSET=${staging}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ASSET }}
+          if-no-files-found: error
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            artifacts/*.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,3 +113,19 @@ cargo run -- sessions --project myproject --limit 5    # project filter
 cargo run -- sql "SELECT COUNT(*) FROM messages"       # raw SQL
 cargo run -- schema --examples                         # see available views + queries
 ```
+
+## Releasing
+
+Releases are cut by pushing a version tag. `.github/workflows/release.yml` then builds
+`cq` for macOS (arm64 + x86_64) and Linux (x86_64 + arm64) and publishes a GitHub
+release with the binaries attached.
+
+```bash
+# bump version in Cargo.toml, commit, then:
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Each target builds on its own native runner because the bundled DuckDB compiles C++
+from source, which makes cross-compiling more trouble than it's worth. There is no
+crates.io publish step today.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ authors = ["Josh Nichols <josh@technicalpickles.com>"]
 # tightened TIMESTAMPTZ arithmetic, dropping the `-(TIMESTAMPTZ, INTERVAL)`
 # overload that `now() - INTERVAL N DAY` relied on. Pin so behavior stays
 # predictable; bump deliberately and re-check timestamp date math when you do.
+#
+# `bundled` is required, not just a build-time preference: the `json` feature
+# transitively enables `bundled` (json -> libduckdb-sys/json -> bundled), and the
+# view layer in views.rs runs entirely on DuckDB's JSON functions (read_json,
+# json_extract). Dropping `bundled` means dropping `json`, which isn't an option.
 duckdb = { version = "=1.10501.0", features = ["bundled", "json"] }
 fs2 = "0.4"
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ cq indexes Claude Code's JSONL session transcripts into a local [DuckDB](https:/
 
 ## Install
 
+### Prebuilt binary
+
+Grab the archive for your platform from the [latest release](https://github.com/technicalpickles/cq/releases/latest), extract it, and put `cq` on your `PATH`. Builds are published for macOS (Apple Silicon and Intel) and Linux (x86_64 and arm64).
+
+### From source
+
 Requires [Rust](https://rustup.rs/).
 
 ```bash


### PR DESCRIPTION
Adds GitHub Actions to this repo, which previously had none. Rebased onto healthy main after #14 (the rustfmt commit that was here originally is now redundant and has been dropped — this branch is workflows + docs only).

## Release workflow (`.github/workflows/release.yml`)
Push a `v*` tag to build `cq` and publish a GitHub release with binaries attached.
- Targets: macOS arm64 + x86_64, Linux x86_64 + arm64
- Each target builds on its **native runner** (no cross-compiling) because `duckdb` bundles its C++ source
- Packages each as a `.tar.gz` (binary + README + LICENSE), uploaded via `gh release create --generate-notes`

## CI workflow (`.github/workflows/ci.yml`)
Runs on pushes to `main` and all PRs: **test** (`cargo test --locked`), **clippy** (`-D warnings`), **fmt** (`--check`).
Caching: test and clippy share a `rust-cache` key so the bundled-DuckDB compile is built once and reused. Incremental compilation off; superseded runs cancelled via `concurrency`.

## Docs
- `Cargo.toml`: note that the `bundled` DuckDB feature is mandatory (`json` transitively forces it)
- `README`: prebuilt-binary install instructions
- `CLAUDE.md`: Releasing section

Diff is workflows + docs only — no code changes, so the CI jobs behave exactly as they do on main (green as of #14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)