### PR TITLE
ci: separate cache keys for test and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared with clippy so the expensive bundled-DuckDB compile is cached
-          # once and reused across both jobs.
-          shared-key: build
+          # Distinct key from clippy: `cargo test` does full codegen while
+          # `cargo clippy` only check-builds (metadata). A shared key let
+          # whichever job saved first win, leaving the other to rebuild from
+          # scratch (test ate a 10m libduckdb-sys recompile against a clippy
+          # cache). Separate keys keep a complete cache per build kind.
+          shared-key: test
       - run: cargo test --locked
 
   clippy:
@@ -38,7 +41,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: build
+          shared-key: clippy
       - run: cargo clippy --locked --all-targets -- -D warnings
 
   fmt:


### PR DESCRIPTION
## Problem
`test` and `clippy` shared one rust-cache key (`shared-key: build`), but they do **different builds**: `cargo test` does full codegen, `cargo clippy` only check-builds (metadata). Whichever job saved the cache first won the key; the other got a "full match" hit on a cache that didn't actually fit its build.

In practice clippy is faster, so it saved first. Then every subsequent run, `test` restored clippy's check-level cache, found no codegen artifacts, and **recompiled libduckdb-sys from scratch (~10 min)** — despite the cache "hitting."

Observed on PR #15's CI run (`28413862833`):
- clippy: **24s** (cache fit) ✅
- test: **10m07s** — `Compiling libduckdb-sys` right after a "full match" restore ❌

## Fix
Give each job its own key (`test` / `clippy`) so it keeps a complete cache for its own kind of build. Both go warm after one run, still running in parallel. Costs ~1 GB extra cache storage, well within GitHub's 10 GB/repo budget.

## Why not share with release.yml too
Different profile (release vs debug) and explicit `--target` vs host build — the artifacts don't match even on the same runner, so there's nothing to share. Releases are infrequent anyway; the caching ROI is all in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)