### PR TITLE
docs: sync CLAUDE.md and CONTEXT.md with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ commands/
   sessions.rs     List/filter sessions
   tools.rs        Tool call queries + summary mode (no filters = grouped counts)
   messages.rs     Message queries
+  projects.rs     `cq projects`: per-project session/message/tool/skill counts
+  context.rs      ContextSqlBuilder: grep-style context windows (-C/--after/--before)
+  mod.rs          Shared arg validators (count-by, fields, context-window conflicts)
   sql.rs          Raw SQL passthrough (intentionally unparameterized)
   schema.rs       View schema docs + example queries (pure text, no DB needed)
 output.rs         Shared rendering: table (comfy-table) or JSON, accepts params
 style.rs          Terminal styling helpers (colors, dim/bold, TTY detection)
-views.rs          Per-provider view SQL (Claude bodies over raw_records) + the composer that UNION ALLs active providers' contributions into the four views; every row carries a `harness` column
+views.rs          Per-provider view SQL (Claude bodies over raw_records) + the composer that UNION ALLs active providers' contributions into the four views; every row carries a `source` column (within-Claude root name) and a `harness` column (`'claude'`)
 db.rs             Orchestrates cache open + indexer sync, registers views, returns DbSetup
 cache.rs          Persistent DuckDB cache at ~/.cache/cq/index.duckdb; schema versioning + rebuild
 indexer.rs        Incremental sync: file_registry + recursive mtime fast-path, fs2 file lock; recurses into <session>/subagents/** and captures agentType from meta.json
@@ -25,11 +28,12 @@ sync_scope.rs     SyncScope: narrows which files the indexer touches (derived fr
 provider.rs       TranscriptProvider trait
 claude_provider.rs  ClaudeProvider: recursively discovers JSONL files (incl. subagents) from ~/.claude/projects/
 scope.rs          QueryScope: --project, --session, --since parsing
+source.rs         Source: named transcript roots (`main` + discovered cenv envs); backs --source
 ```
 
 ## Design principles
 
-CQ is a query tool, not a monitoring tool. Default is auto-scope to the current project directory; `--all` escapes to global. Stale-but-available beats error. Explicit always wins (`--reindex`/`--no-reindex` override all automatic behavior). See `docs/design-principles.md` for the full reference.
+CQ is a query tool, not a monitoring tool. Default is auto-scope to the current project directory; `--all` escapes to global. Sources scope the same way: `--source <name>` targets one transcript root, else cq auto-scopes to the active source (matched via `CLAUDE_CONFIG_DIR`), and `--all` spans all sources. Stale-but-available beats error. Explicit always wins (`--reindex`/`--no-reindex` override all automatic behavior). See `docs/design-principles.md` for the full reference, and `CONTEXT.md` for the Harness/Provider/Source glossary.
 
 ## Key patterns
 
@@ -98,9 +102,10 @@ The pattern: `let wide = cli.wide || !std::io::stdout().is_terminal();`
 cargo test              # all tests (unit + integration + view tests)
 ```
 
-- `tests/views_test.rs` (20 tests): View SQL correctness against fixture JSONL files
-- `tests/integration_test.rs` (12 tests): End-to-end CLI tests with `assert_cmd`
-- `src/` unit tests (14 tests): Scope parsing, path encoding, file discovery
+- `tests/views_test.rs`: View SQL correctness against fixture JSONL files
+- `tests/integration_test.rs`: End-to-end CLI tests with `assert_cmd`
+- `tests/cache_test.rs`: Cache open / schema-version / rebuild behavior
+- `src/` unit tests: Scope parsing, path encoding, file discovery, source discovery
 
 Fixtures live in `tests/fixtures/` as handcrafted JSONL files.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,8 +21,8 @@ _Avoid_: using "source" to mean a different harness.
 - A **Harness** is read by exactly one **Provider**.
 - The Claude **Provider** spans one or more **Sources** (main + cenv envs); `--source` scopes within it.
 - The opencode **Provider** has no **Sources** in the current sense — its storage is a single SQLite DB, not a directory of JSONL roots.
-- The `source` column in the cq views is really a **harness/provider** tag (`'claude'` / `'opencode'`), distinct from the `--source` flag's within-Claude meaning. (Flagged below.)
+- The cq views carry two distinct columns: `harness` is the harness/provider tag (`'claude'` / `'opencode'`), and `source` is the within-Claude root name that the `--source` flag selects (`main` + cenv envs).
 
 ## Flagged ambiguities
 
-- "source" was used in the opencode findings doc to mean "a new harness" (`'opencode'` source). Resolved: that is a **Provider**/**Harness**, not a **Source**. cq's existing `Source` keeps its narrow within-Claude meaning. The overload on the views' `source` column vs. the `--source` flag is a known wart to resolve when designing the views.
+- "source" was used in the opencode findings doc to mean "a new harness" (`'opencode'` source). Resolved: that is a **Provider**/**Harness**, not a **Source**. cq's existing `Source` keeps its narrow within-Claude meaning. The earlier overload on the views' `source` column was resolved by giving the views a separate `harness` column for the provider tag, leaving `source` to mean the within-Claude root name (matching the `--source` flag).


### PR DESCRIPTION
## What

CLAUDE.md and CONTEXT.md had drifted from the codebase. This brings them back in sync.

### CLAUDE.md
- **Architecture tree:** add `source.rs` and `commands/{projects,context,mod}.rs` (all real modules that were missing)
- **views.rs line:** document both the `source` (within-Claude root name) and `harness` (`'claude'`) columns; it previously mentioned only `harness`, but the code emits both on every row
- **Design principles:** document the `--source` scoping axis (explicit wins, else auto-scope via `CLAUDE_CONFIG_DIR`, `--all` spans all sources) and add a pointer to `CONTEXT.md`
- **Tests:** add `tests/cache_test.rs`; drop the per-file test counts, which were all stale (20→32, 12→95, 14→57) and rot fast

### CONTEXT.md
The views' `source`-column overload described as an open "wart" is actually resolved in code: the views now have separate `source` and `harness` columns. Updated the Relationships bullet to describe the two columns, and rewrote the flagged ambiguity as resolved.

## Why

Verified every change against the current code (`main.rs`, `views.rs`, `commands/`, `tests/`). No behavior change, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)