### PR TITLE
ci: pin Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned: a rolling `stable` changes the rustc version, which is part of
+      # the rust-cache key, so every new release silently invalidates the cache
+      # and forces a full ~10m libduckdb-sys rebuild. Bump this deliberately.
+      - uses: dtolnay/rust-toolchain@1.96.0
       - uses: Swatinem/rust-cache@v2
         with:
           # Distinct key from clippy: `cargo test` does full codegen while
@@ -36,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0 # pinned (see test job)
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -49,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0 # pinned (see test job)
         with:
           components: rustfmt
       - run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to match CI (.github/workflows/ci.yml) so release binaries
+        # build against a known compiler. Bump both together.
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
## What

Pin the Rust toolchain to `1.96.0` in both CI and release workflows, replacing the rolling `dtolnay/rust-toolchain@stable`.

## Why

A rolling `stable` changes the rustc version, and the rustc version is part of the `rust-cache` key. Every new stable Rust release silently invalidated the cache, which forced a full ~10m `libduckdb-sys` C++ rebuild on both the `test` and `clippy` jobs. That's the "why does CI take 10 minutes" seen on #18 (both jobs logged `No cache found`).

Pinning keeps the cache key stable across runs so warm-cache runs stay fast. Bump the version deliberately when you want a newer toolchain (bump CI + release together).

## Notes

- `1.96.0` matches the current local dev toolchain.
- Release workflow pinned too, so release binaries build against a known compiler.
- The first run on this branch is still a cold cache (new key), so expect one slow run; subsequent runs should restore cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)