### PR TITLE
docs: add run-cq skill to build, run, and smoke-drive the CLI

### DIFF
--- a/.claude/skills/run-cq/SKILL.md
+++ b/.claude/skills/run-cq/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: run-cq
+description: Build, run, test, and smoke-drive cq — the SQL-over-Claude-Code-transcripts CLI (Rust + DuckDB). Use when asked to build cq, run it, try a subcommand, verify a change works end-to-end, or run its tests.
+---
+
+`cq` is a Rust CLI that indexes Claude Code JSONL session transcripts into a
+DuckDB cache and queries them with SQL. No server, no UI — you drive it by
+running subcommands and checking output + exit codes.
+
+**Agent path:** run `.claude/skills/run-cq/smoke.sh` — it builds the release
+binary if missing, then exercises every subcommand against an isolated cache and
+asserts exit codes (including the error path). All paths below are relative to
+the repo root.
+
+Verified on macOS (Darwin, arm64). Linux is a first-class target too (CI ships
+Linux x86_64 + arm64 builds), but the commands below were run on macOS.
+
+## Prerequisites
+
+- **Rust toolchain** (`cargo`, `rustc`). Verified with 1.96.
+- **A C++ compiler.** The `duckdb` crate is pinned with the `bundled` feature, so
+  it compiles DuckDB from C++ source on first build. macOS: Xcode Command Line
+  Tools (`xcode-select --install`) provide `clang`. Ubuntu: `sudo apt-get install -y build-essential`.
+
+No system DuckDB, no other services. The tool reads `~/.claude/projects/` (or
+`$CQ_PROJECTS_DIR`) and writes a cache at `~/.cache/cq/index.duckdb` (or
+`$CQ_CACHE_DIR`).
+
+## Build
+
+```bash
+cargo build --release
+# → target/release/cq  (first build ~4 min: DuckDB compiles from source; later builds are seconds)
+./target/release/cq --version
+# → cq 0.2.0
+```
+
+## Run (agent path)
+
+The smoke driver is the fastest way to confirm a working binary. It uses an
+isolated `CQ_CACHE_DIR` under `$TMPDIR`, so it never touches your real cache:
+
+```bash
+.claude/skills/run-cq/smoke.sh
+# builds if needed, then:
+#   ok   version (exit 0)
+#   ok   tools summary (exit 0)
+#   ...
+#   ok   error: bad --count-by (exit 1)
+#   ALL CHECKS PASSED
+```
+
+Exit 0 = every check passed. It drives: `--version`, `--help`, `tools`,
+`sessions`, `messages`, `projects`, `sql`, `schema --examples`, `--json`
+output, and one deliberate error case that must exit 1.
+
+To poke it by hand (these all ran clean on real session data):
+
+```bash
+BIN=./target/release/cq
+$BIN tools --all --limit 10                          # bar-chart summary of tool usage
+$BIN sessions --all --limit 3                        # recent sessions
+$BIN sql "SELECT COUNT(*) AS n FROM messages"        # raw SQL over the four views
+$BIN schema --examples                               # view schema + example queries (no DB needed)
+$BIN sessions --all --limit 1 --json                 # machine-readable output
+```
+
+`--all` disables auto-scoping to the current directory. Without it, queries scope
+to the project matching your cwd (from the repo root you'll get cq's own
+sessions, which may be sparse).
+
+## Run (human path)
+
+Same binary, no wrapper: `cargo run -- <subcommand>`, e.g.
+`cargo run -- tools --limit 5`. See `README.md` and `docs/` for the tour.
+
+## Test
+
+```bash
+cargo test
+# → 5 suites: lib (57), cache (11), integration (95), views (32), + 0 doc-tests. All pass in ~20s.
+```
+
+Fixtures are handcrafted JSONL under `tests/fixtures/`; tests don't need your
+real `~/.claude/projects/` data.
+
+## Gotchas
+
+- **`--all` matters for a visible result.** cq defaults to auto-scoping to the
+  current directory's project. Run from the repo root without `--all` and you
+  only see cq's own sessions. Use `--all` (or `--project <name>`) to see
+  everything. An over-scoped query prints `No results.` plus an `Active filters:`
+  hint — that's exit 0, not a failure.
+- **First build is slow, and it's the C++, not your code.** `bundled` DuckDB
+  compiles from source (~4 min). If a build hangs on `libduckdb-sys`, it's
+  compiling, not stuck.
+- **`--reindex` waits for the file lock; `--no-reindex` skips sync entirely.**
+  Default (`Auto`) does an mtime fast-path and skips if the lock is busy, so a
+  concurrent cq won't block you — you just read slightly stale data.
+- **Writing under `.claude/skills/` may hit a sandbox deny rule.** If you edit
+  this skill or `smoke.sh` and the write is refused, that's the tool sandbox, not
+  a permissions bug — `.claude/skills` is on the deny list. Manage with `/sandbox`.
+
+## Troubleshooting
+
+- **`Error: Unknown count-by column '<x>' for tools` (exit 1)** — expected for an
+  invalid `--count-by`. Valid columns: `name`, `session`, `project`. The smoke
+  driver relies on this exiting non-zero.
+- **Fresh/empty `CQ_CACHE_DIR`** — first run prints `Synced N new files` and
+  builds `index.duckdb` + `index.lock` from scratch (a couple seconds for ~500
+  files). Not an error.

--- a/.claude/skills/run-cq/smoke.sh
+++ b/.claude/skills/run-cq/smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Smoke driver for cq — builds the release binary if needed, then drives every
+# subcommand against an ISOLATED fresh cache so it never touches the user's real
+# ~/.cache/cq/index.duckdb. Asserts exit codes (including the error path).
+#
+# Reads real transcripts from ~/.claude/projects (or $CQ_PROJECTS_DIR). Works
+# even with zero session data — commands print "No results." and exit 0.
+#
+# Usage:  .claude/skills/run-cq/smoke.sh
+# Run from the repo root. Exit 0 = all checks passed.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+BIN="$PWD/target/release/cq"
+
+# Isolated cache so the smoke run is hermetic and doesn't disturb the real index.
+CACHE="$(mktemp -d "${TMPDIR:-/tmp}/cq-smoke.XXXXXX")"
+export CQ_CACHE_DIR="$CACHE"
+trap 'rm -rf "$CACHE"' EXIT
+
+fail=0
+pass() { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1"; fail=1; }
+
+# check <label> <expected-exit> -- <command...>
+check() {
+  local label=$1 want=$2; shift 3
+  "$@" >/tmp/cq-smoke.out 2>&1
+  local got=$?
+  if [ "$got" -eq "$want" ]; then pass "$label (exit $got)"
+  else bad "$label (want exit $want, got $got)"; sed 's/^/       | /' /tmp/cq-smoke.out; fi
+}
+
+echo "== build =="
+if [ ! -x "$BIN" ]; then
+  echo "release binary missing — building (DuckDB compiles from source, ~4 min)"
+  cargo build --release || { echo "build failed"; exit 1; }
+fi
+"$BIN" --version || exit 1
+
+echo "== drive subcommands (isolated cache: $CACHE) =="
+check "version"          0 -- "$BIN" --version
+check "help"             0 -- "$BIN" --help
+check "tools summary"    0 -- "$BIN" tools --all --limit 5
+check "sessions"         0 -- "$BIN" sessions --all --limit 3
+check "messages"         0 -- "$BIN" messages --all --limit 3
+check "projects"         0 -- "$BIN" projects --all
+check "raw sql"          0 -- "$BIN" sql "SELECT COUNT(*) AS n FROM messages"
+check "schema --examples" 0 -- "$BIN" schema --examples
+check "json output"      0 -- "$BIN" sessions --all --limit 1 --json
+# Forgiveness path: an invalid enum value must exit non-zero with a helpful error.
+check "error: bad --count-by" 1 -- "$BIN" tools --count-by bogus
+
+echo "== result =="
+if [ "$fail" -eq 0 ]; then echo "ALL CHECKS PASSED"; else echo "SOME CHECKS FAILED"; fi
+exit "$fail"


### PR DESCRIPTION
Adds a `/run-cq` skill so a future agent (or human) can build, launch, and drive `cq` from a clean checkout.

## What's here

- **`.claude/skills/run-cq/SKILL.md`** — the man page. Points at the driver first, then documents the verified build/test flow and the real gotchas. Frontmatter description carries the verbs an agent would type (build, run, test, try a subcommand, verify a change).
- **`.claude/skills/run-cq/smoke.sh`** — the driver. Builds the release binary if missing, then exercises every subcommand (`tools`, `sessions`, `messages`, `projects`, `sql`, `schema`, `--json`) against an **isolated `CQ_CACHE_DIR`** so it never touches the real `~/.cache/cq/index.duckdb`, and asserts exit codes — including one deliberate error case that must exit 1.

## Verified (macOS, arm64)

- Clean `cargo build --release` from scratch: ~4 min (DuckDB `bundled` compiles C++ from source), later builds are seconds.
- Drove all subcommands against real session data — bar-chart summary, JSON, raw SQL all work.
- `--count-by bogus` → templated error, exit 1.
- Full test suite: 195 tests across 5 suites, all pass in ~20s.
- Ran the driver end-to-end: `ALL CHECKS PASSED`, then followed `SKILL.md` line-by-line in a fresh shell.

Not verified on Linux (CI ships Linux builds); the skill says so plainly and gives the Ubuntu `build-essential` line without pretending it was run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)