### PR TITLE
chore: gitignore stray index.duckdb/index.lock in repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /.scratch/
 /.superpowers/
 eval_set.json
+
+# Stray DuckDB cache if CQ_CACHE_DIR resolves to the repo root (e.g. empty/unset)
+/index.duckdb
+/index.lock


### PR DESCRIPTION
If `CQ_CACHE_DIR` resolves to the repo root (set empty, or unset in a way that falls back to cwd), `cq` drops `index.duckdb` + `index.lock` there. Since these names weren't ignored, a stray ~460MB cache could get staged by accident (which is exactly what happened while building the run-cq skill).

Adds both to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)