### PR TITLE
docs(skill): warn against merging stderr into stdout on JSON pipes

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cq",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Query past Claude Code sessions via the cq CLI (SQL over session transcripts). Teaches Claude when and how to invoke cq to answer questions about session history, tool usage, errors, and past commands.",
   "author": {
     "name": "Josh Nichols",

--- a/claude-plugin/skills/cq/SKILL.md
+++ b/claude-plugin/skills/cq/SKILL.md
@@ -77,6 +77,7 @@ LIMIT 20;
 
 - Use `--json` when parsing output programmatically or piping to other tools.
 - Do not suppress stderr on a cq pipe (`cq ... --json 2>/dev/null | ...`). If the SQL errors, the error goes to stderr and stdout is empty, so the downstream consumer (e.g. `python3 -c json.load`) dies with a confusing `Expecting value: line 1 column 1` instead of the real cq error. Let stderr through, or redirect to a temp file and check it.
+- Do not merge stderr into stdout on a cq pipe either (`cq ... --json 2>&1 | ...`). Progress messages ("Loaded N files", "Synced N new files") are written to stderr by design so stdout stays clean JSON; merging the streams puts those lines back in front of the JSON and breaks the parser. Redirect stderr to a file or the terminal instead: `cq ... --json 2>/tmp/cq.err | ...`.
 - The convenience subcommands (`sessions`, `tools`, `messages`) cover most needs. Reach for `cq sql` when you need joins or aggregations across views.
 - `--since` filters the convenience subcommands (`sessions`, `tools`, `messages`), but NOT `cq sql`: raw SQL runs verbatim and ignores `--since`/`--project`/`--session`. On `cq sql`, filter time with a string comparison instead, e.g. `WHERE timestamp >= '2026-05-28'`. cq uses DuckDB, not SQLite, so SQLite functions like `datetime()` will not work. Do NOT reach for `WHERE timestamp > now() - INTERVAL N DAY`: it errors (see Tips below).
 - `cq` auto-scopes to the current directory's project. The scope hint shows which path is being matched.


### PR DESCRIPTION
## Summary
- Session-history mining via `cq sql` itself turned up a recurring footgun: piping `cq ... --json 2>&1 | python3 -c "json.load(...)"` merges cq's stderr progress lines ("Loaded N files") back into the JSON stream, breaking the parser.
- The skill already warns against suppressing stderr (`2>/dev/null`) but not against merging it in (`2>&1`), which is the opposite mistake with the same failure mode (broken JSON parsing downstream).

## Test plan
- [x] Reproduced the failure pattern by grepping past session transcripts with `cq sql` for `cq ... --json 2>&1 | python3` invocations that crashed on JSON parsing
- [x] Confirmed `cq sql ... --json` writes only JSON to stdout and progress messages to stderr (verified with separate stdout/stderr redirects)