### PR TITLE
feat: multi-value --grep (OR match) and --result-grep for tool output content

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cargo install --git https://github.com/technicalpickles/cq
 cq sessions                              # your recent sessions
 cq tools                                 # tool usage, ranked
 cq messages --grep "docker" --since 7d   # search your history
+cq tools --errors --result-grep "ECONNREFUSED"  # what failed, and why
 cq hooks                                 # hook events, ranked (SessionStart, PreToolUse, ...)
 cq sql "SELECT count(*) FROM messages"   # run anything
 ```

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cq",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Query past Claude Code sessions via the cq CLI (SQL over session transcripts). Teaches Claude when and how to invoke cq to answer questions about session history, tool usage, errors, and past commands.",
   "author": {
     "name": "Josh Nichols",

--- a/claude-plugin/skills/cq/SKILL.md
+++ b/claude-plugin/skills/cq/SKILL.md
@@ -33,9 +33,9 @@ user_invocable: true
 
 ## Subcommand Flags
 
-- **sessions**: `--grep` (filter by content)
-- **tools**: `--grep` (filter inputs), `--errors` (errors only), `--fields` (extract input fields as columns)
-- **messages**: `--type user|assistant`, `--grep`
+- **sessions**: `--grep` (filter by content, repeatable/OR)
+- **tools**: `--grep` (filter inputs, repeatable/OR), `--result-grep` (filter by tool result content, repeatable/OR, ANDs with `--errors`), `--errors` (errors only), `--fields` (extract input fields as columns)
+- **messages**: `--type user|assistant`, `--grep` (repeatable/OR)
 
 ## View Schemas
 
@@ -78,7 +78,9 @@ LIMIT 20;
 - Use `--json` when parsing output programmatically or piping to other tools.
 - Do not suppress stderr on a cq pipe (`cq ... --json 2>/dev/null | ...`). If the SQL errors, the error goes to stderr and stdout is empty, so the downstream consumer (e.g. `python3 -c json.load`) dies with a confusing `Expecting value: line 1 column 1` instead of the real cq error. Let stderr through, or redirect to a temp file and check it.
 - Do not merge stderr into stdout on a cq pipe either (`cq ... --json 2>&1 | ...`). Progress messages ("Loaded N files", "Synced N new files") are written to stderr by design so stdout stays clean JSON; merging the streams puts those lines back in front of the JSON and breaks the parser. Redirect stderr to a file or the terminal instead: `cq ... --json 2>/tmp/cq.err | ...`.
-- The convenience subcommands (`sessions`, `tools`, `messages`) cover most needs. Reach for `cq sql` when you need joins or aggregations across views.
+- The convenience subcommands (`sessions`, `tools`, `messages`, `hooks`) cover most needs. Reach for `cq sql` when you need joins or aggregations across views.
+- `--grep` can be repeated for an OR search (`--grep foo --grep bar` matches either), so a multi-term keyword sweep doesn't need to drop to raw SQL with a chain of `ILIKE ... OR ILIKE ...`.
+- `tools --grep` searches the tool call's input (what was asked for); `tools --result-grep` searches the tool result's content (what came back, e.g. error text or output). Before `--result-grep` existed, searching result content required a raw `tool_calls JOIN tool_results` query — reach for `cq sql` only if you also need aggregation across that join, not just a text match.
 - `--since` filters the convenience subcommands (`sessions`, `tools`, `messages`), but NOT `cq sql`: raw SQL runs verbatim and ignores `--since`/`--project`/`--session`. On `cq sql`, filter time with a string comparison instead, e.g. `WHERE timestamp >= '2026-05-28'`. cq uses DuckDB, not SQLite, so SQLite functions like `datetime()` will not work. Do NOT reach for `WHERE timestamp > now() - INTERVAL N DAY`: it errors (see Tips below).
 - `cq` auto-scopes to the current directory's project. The scope hint shows which path is being matched.
 - Use `--project <name>` to query a different project (substring match, searches all project directories).
@@ -103,6 +105,16 @@ What does NOT work on the raw columns:
 
 - `now() - INTERVAL N DAY` errors with `No function matches '-(TIMESTAMP WITH TIME ZONE, INTERVAL)'`. Compare against a string literal, or cast with `now()::TIMESTAMP - INTERVAL N DAY`. cq surfaces this hint automatically when the query fails.
 - `strftime(...)`, `date_trunc(...)`, `extract(...)` need a real timestamp. For genuine per-row date math (e.g. correlating events within a window), cast inline: `timestamp::TIMESTAMP`.
+
+### Aliasing extracted fields: avoid existing column names
+
+`tool_calls` already has real columns named `agent_id`, `agent_type`, `session_id`, `project`, `source`, `harness`, `is_sidechain`, and `workflow_id` (see `cq schema tool_calls`). If you `SELECT json_extract_string(input, '$.some_field') AS agent_type` and then `GROUP BY agent_type`, DuckDB resolves the `GROUP BY` reference to the *real* `agent_type` column, not your alias, since column names win over aliases. The result is a confusing error unrelated to the actual mistake:
+
+```
+Error: Binder Error: column "input" must appear in the GROUP BY clause or must be part of an aggregate function.
+```
+
+The fix is just to pick an alias that doesn't collide, e.g. `AS extracted_agent_type`. This only bites when the alias happens to match a real column name on the view you're querying — check `cq schema <view>` if a `GROUP BY` error mentions a column you don't remember referencing.
 
 ## Error Recovery
 

--- a/docs/cli-ux-conventions.md
+++ b/docs/cli-ux-conventions.md
@@ -129,6 +129,22 @@ If you add a new alias, make sure it works in every flag that accepts columns. I
 
 Users don't need to think about this difference. They write `--fields text` or `--fields command` and get the data.
 
+## Repeatable filters (`--grep`)
+
+`--grep` can be passed more than once. Repeats are OR'd together, not AND'd: `--grep foo --grep bar` matches rows containing "foo" OR "bar". This mirrors ripgrep's `-e` and grep's `-e`/`-f`, and means a multi-term search never has to fall back to raw `cq sql` with a chain of `ILIKE ... OR ILIKE ...`.
+
+In clap, this means the field is `Vec<String>` (not `Option<String>`) with no `value_delimiter` — each `--grep` occurrence is its own pattern, so a pattern containing a literal comma still works.
+
+```bash
+cq messages --grep "docker" --grep "podman"   # either term
+```
+
+### `--grep` vs `--result-grep` on `tools`
+
+`tools --grep` searches `tool_calls.input` (what the agent asked for). `tools --result-grep` searches `tool_results.content` (what came back) — the actual output text, not just whether it errored. `--errors` and `--result-grep` compose with AND: `--errors --result-grep "ECONNREFUSED"` finds failed calls whose output mentions that string specifically, narrower than `--errors` alone.
+
+Before `--result-grep`, searching tool output text required raw SQL with a `tool_calls JOIN tool_results` — there was no subcommand path to it at all.
+
 ## Context flags (`-A`/`-B`/`-C`)
 
 cq mirrors grep's context flags on `tools` and `messages`:

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -43,7 +43,7 @@ pub fn run(
     conn: &Connection,
     scope: &QueryScope,
     event: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     count_by: Option<&str>,
     format: &OutputFormat,
     limit: usize,
@@ -57,7 +57,7 @@ pub fn run(
     }
 
     // Summary mode: no filters specified
-    if event.is_none() && grep.is_none() {
+    if event.is_none() && grep.is_empty() {
         return run_summary(conn, scope, format, wide);
     }
 
@@ -89,9 +89,9 @@ pub fn run(
         params.push(Box::new(e.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("content ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("content", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");
@@ -143,7 +143,7 @@ pub fn run(
             super::print_session_not_found(session);
         } else {
             let mut extras: Vec<&str> = Vec::new();
-            if grep.is_some() {
+            if !grep.is_empty() {
                 extras.push("--grep");
             }
             if event.is_some() {
@@ -176,7 +176,7 @@ fn run_count_by(
     conn: &Connection,
     scope: &QueryScope,
     event: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     column: &str,
     format: &OutputFormat,
     wide: bool,
@@ -209,9 +209,9 @@ fn run_count_by(
         params.push(Box::new(e.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("content ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("content", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");

--- a/src/commands/messages.rs
+++ b/src/commands/messages.rs
@@ -38,7 +38,7 @@ pub fn run(
     conn: &Connection,
     scope: &QueryScope,
     msg_type: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     fields: Option<&[&str]>,
     count_by: Option<&str>,
     ctx: Option<super::ContextWindow>,
@@ -108,9 +108,9 @@ pub fn run(
         params.push(Box::new(t.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("text ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("text", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");
@@ -154,7 +154,7 @@ pub fn run(
                     if msg_type.is_some() {
                         extras.push("--type");
                     }
-                    if grep.is_some() {
+                    if !grep.is_empty() {
                         extras.push("--grep");
                     }
                     super::print_no_results(scope, &extras);
@@ -186,7 +186,7 @@ fn run_with_context(
     conn: &Connection,
     scope: &QueryScope,
     msg_type: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     window: super::ContextWindow,
     format: &OutputFormat,
     match_limit: usize,
@@ -216,8 +216,8 @@ fn run_with_context(
     if let Some(_t) = msg_type {
         match_conditions.push("type = ?".to_string());
     }
-    if let Some(_pattern) = grep {
-        match_conditions.push("text ILIKE ?".to_string());
+    if let Some(clause) = super::grep_where("text", grep) {
+        match_conditions.push(clause);
     }
     let match_where = match_conditions.join(" AND ");
 
@@ -246,9 +246,7 @@ fn run_with_context(
     if let Some(t) = msg_type {
         all_params.push(Box::new(t.to_string()));
     }
-    if let Some(pattern) = grep {
-        all_params.push(Box::new(format!("%{pattern}%")));
-    }
+    all_params.extend(super::grep_params(grep));
 
     let param_refs: Vec<&dyn duckdb::types::ToSql> =
         all_params.iter().map(|p| p.as_ref()).collect();
@@ -267,7 +265,7 @@ fn run_with_context(
             if msg_type.is_some() {
                 extras.push("--type");
             }
-            if grep.is_some() {
+            if !grep.is_empty() {
                 extras.push("--grep");
             }
             super::print_no_results(scope, &extras);
@@ -296,7 +294,7 @@ fn run_with_fields(
     conn: &Connection,
     scope: &QueryScope,
     msg_type: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     field_list: &[&str],
     format: &OutputFormat,
     limit: usize,
@@ -331,9 +329,9 @@ fn run_with_fields(
         params.push(Box::new(t.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("text ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("text", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");
@@ -361,7 +359,7 @@ fn run_count_by(
     conn: &Connection,
     scope: &QueryScope,
     msg_type: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     column: &str,
     format: &OutputFormat,
     wide: bool,
@@ -394,9 +392,9 @@ fn run_count_by(
         params.push(Box::new(t.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("text ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("text", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -111,6 +111,29 @@ pub fn check_count_by_fields_conflict(count_by: Option<&str>, fields: Option<&[&
     }
 }
 
+/// Build an OR'd ILIKE clause for one or more --grep patterns against `column_expr`.
+/// Returns None when `patterns` is empty (no filter to apply).
+/// Each pattern becomes its own `column_expr ILIKE ?` bound via `grep_params`, so
+/// `--grep foo --grep bar` matches rows containing "foo" OR "bar", not both.
+pub fn grep_where(column_expr: &str, patterns: &[String]) -> Option<String> {
+    if patterns.is_empty() {
+        return None;
+    }
+    let clauses: Vec<String> = patterns
+        .iter()
+        .map(|_| format!("{column_expr} ILIKE ?"))
+        .collect();
+    Some(format!("({})", clauses.join(" OR ")))
+}
+
+/// Params for a `grep_where` clause, in the same pattern order.
+pub fn grep_params(patterns: &[String]) -> Vec<Box<dyn duckdb::types::ToSql>> {
+    patterns
+        .iter()
+        .map(|p| Box::new(format!("%{p}%")) as Box<dyn duckdb::types::ToSql>)
+        .collect()
+}
+
 /// Render a bar chart from (label, count) pairs. Used by --count-by and tools summary mode.
 pub fn render_bar_chart(rows: &[(String, i64)]) {
     let max_count = rows.iter().map(|r| r.1).max().unwrap_or(1);

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -75,7 +75,7 @@ const VALID_COUNT_BY_COLUMNS: &[&str] = &["project"];
 pub fn run(
     conn: &Connection,
     scope: &QueryScope,
-    grep: Option<&str>,
+    grep: &[String],
     fields: Option<&[&str]>,
     count_by: Option<&str>,
     format: &OutputFormat,
@@ -142,9 +142,9 @@ pub fn run(
         conditions.push(format!("started_at >= '{formatted}'"));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("first_user_message ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("first_user_message", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");
@@ -193,7 +193,7 @@ pub fn run(
                     super::print_session_not_found(session);
                 } else {
                     let mut extras: Vec<&str> = Vec::new();
-                    if grep.is_some() {
+                    if !grep.is_empty() {
                         extras.push("--grep");
                     }
                     super::print_no_results(scope, &extras);
@@ -224,7 +224,7 @@ pub fn run(
 fn run_with_fields(
     conn: &Connection,
     scope: &QueryScope,
-    grep: Option<&str>,
+    grep: &[String],
     field_list: &[&str],
     format: &OutputFormat,
     limit: usize,
@@ -254,9 +254,9 @@ fn run_with_fields(
         conditions.push(format!("started_at >= '{formatted}'"));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("first_user_message ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("first_user_message", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");
@@ -283,7 +283,7 @@ fn run_with_fields(
 fn run_count_by(
     conn: &Connection,
     scope: &QueryScope,
-    grep: Option<&str>,
+    grep: &[String],
     column: &str,
     format: &OutputFormat,
     wide: bool,
@@ -311,9 +311,9 @@ fn run_count_by(
         conditions.push(format!("started_at >= '{formatted}'"));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("first_user_message ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("first_user_message", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
 
     let where_clause = conditions.join(" AND ");

--- a/src/commands/tools.rs
+++ b/src/commands/tools.rs
@@ -48,7 +48,8 @@ pub fn run(
     conn: &Connection,
     scope: &QueryScope,
     tool_name: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
+    result_grep: &[String],
     errors_only: bool,
     fields: Option<&[&str]>,
     count_by: Option<&str>,
@@ -62,6 +63,13 @@ pub fn run(
     super::check_count_by_fields_conflict(count_by, fields);
     super::check_count_by_context_conflict(count_by, ctx);
     super::check_fields_context_conflict(fields, ctx);
+    if !result_grep.is_empty() && ctx.is_some() {
+        eprintln!(
+            "Error: --result-grep cannot be used with -A, -B, or -C\n\
+             Use --errors or --grep for context-window searches; --result-grep is detail-mode only"
+        );
+        std::process::exit(1);
+    }
 
     // Dispatch to context mode
     if let Some(window) = ctx {
@@ -86,6 +94,7 @@ pub fn run(
             scope,
             tool_name,
             grep,
+            result_grep,
             errors_only,
             &resolved,
             format,
@@ -94,7 +103,12 @@ pub fn run(
     }
 
     // Summary mode: no filters specified (and no fields requested)
-    if tool_name.is_none() && grep.is_none() && !errors_only && fields.is_none() {
+    if tool_name.is_none()
+        && grep.is_empty()
+        && result_grep.is_empty()
+        && !errors_only
+        && fields.is_none()
+    {
         return run_summary(conn, scope, format, wide);
     }
 
@@ -126,10 +140,27 @@ pub fn run(
         params.push(Box::new(name.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("CAST(tc.input AS VARCHAR) ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("CAST(tc.input AS VARCHAR)", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
     }
+
+    if errors_only {
+        conditions.push("tr.is_error = true".to_string());
+    }
+
+    if let Some(clause) = super::grep_where("tr.content", result_grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(result_grep));
+    }
+
+    // tr.is_error / tr.content above only resolve when tool_results is joined.
+    let needs_results_join = errors_only || !result_grep.is_empty();
+    let results_join_clause = if needs_results_join {
+        "JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id"
+    } else {
+        ""
+    };
 
     let where_clause = conditions.join(" AND ");
     let limit_clause = super::limit_clause(limit);
@@ -145,7 +176,7 @@ pub fn run(
             &where_clause,
             &param_refs,
             field_list,
-            errors_only,
+            needs_results_join,
             format,
             limit,
             offset,
@@ -155,52 +186,28 @@ pub fn run(
 
     // JSON gets full column set for scripting; display gets only what's shown
     if matches!(format, OutputFormat::Json) {
-        let sql = if errors_only {
-            format!(
-                "SELECT tc.session_id, tc.project, tc.name, tc.tool_use_id, tc.timestamp, CAST(tc.input AS VARCHAR) AS input
-                 FROM tool_calls tc
-                 JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id
-                 WHERE {where_clause}
-                 AND tr.is_error = true
-                 ORDER BY tc.timestamp DESC
-                 {limit_clause}
-                 {offset_clause}"
-            )
-        } else {
-            format!(
-                "SELECT tc.session_id, tc.project, tc.name, tc.tool_use_id, tc.timestamp, CAST(tc.input AS VARCHAR) AS input
-                 FROM tool_calls tc
-                 WHERE {where_clause}
-                 ORDER BY tc.timestamp DESC
-                 {limit_clause}
-                 {offset_clause}"
-            )
-        };
+        let sql = format!(
+            "SELECT tc.session_id, tc.project, tc.name, tc.tool_use_id, tc.timestamp, CAST(tc.input AS VARCHAR) AS input
+             FROM tool_calls tc
+             {results_join_clause}
+             WHERE {where_clause}
+             ORDER BY tc.timestamp DESC
+             {limit_clause}
+             {offset_clause}"
+        );
         let mut stmt = conn.prepare(&sql)?;
         return output::print_results(&mut stmt, &param_refs, format, wide);
     }
 
-    let sql = if errors_only {
-        format!(
-            "SELECT tc.session_id, tc.name, CAST(tc.input AS VARCHAR) AS input
-             FROM tool_calls tc
-             JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id
-             WHERE {where_clause}
-             AND tr.is_error = true
-             ORDER BY tc.timestamp DESC
-             {limit_clause}
-             {offset_clause}"
-        )
-    } else {
-        format!(
-            "SELECT tc.session_id, tc.name, CAST(tc.input AS VARCHAR) AS input
-             FROM tool_calls tc
-             WHERE {where_clause}
-             ORDER BY tc.timestamp DESC
-             {limit_clause}
-             {offset_clause}"
-        )
-    };
+    let sql = format!(
+        "SELECT tc.session_id, tc.name, CAST(tc.input AS VARCHAR) AS input
+         FROM tool_calls tc
+         {results_join_clause}
+         WHERE {where_clause}
+         ORDER BY tc.timestamp DESC
+         {limit_clause}
+         {offset_clause}"
+    );
 
     let mut stmt = conn.prepare(&sql)?;
 
@@ -222,8 +229,11 @@ pub fn run(
             super::print_session_not_found(session);
         } else {
             let mut extras: Vec<&str> = Vec::new();
-            if grep.is_some() {
+            if !grep.is_empty() {
                 extras.push("--grep");
+            }
+            if !result_grep.is_empty() {
+                extras.push("--result-grep");
             }
             if errors_only {
                 extras.push("--errors");
@@ -243,16 +253,12 @@ pub fn run(
 
     super::print_truncation_hint(
         conn,
-        if errors_only {
+        if needs_results_join {
             "tool_calls tc JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id"
         } else {
             "tool_calls tc"
         },
-        &if errors_only {
-            format!("{where_clause} AND tr.is_error = true")
-        } else {
-            where_clause.clone()
-        },
+        &where_clause,
         &param_refs,
         detail_rows.len(),
         limit,
@@ -266,7 +272,7 @@ fn run_with_context(
     conn: &Connection,
     scope: &crate::scope::QueryScope,
     tool_name: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
     errors_only: bool,
     window: super::ContextWindow,
     format: &OutputFormat,
@@ -311,9 +317,9 @@ fn run_with_context(
         tool_conditions.push("tc.name = ?".to_string());
         tool_params.push(Box::new(name.to_string()));
     }
-    if let Some(pattern) = grep {
-        tool_conditions.push("CAST(tc.input AS VARCHAR) ILIKE ?".to_string());
-        tool_params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("CAST(tc.input AS VARCHAR)", grep) {
+        tool_conditions.push(clause);
+        tool_params.extend(super::grep_params(grep));
     }
     let tool_where = tool_conditions.join(" AND ");
 
@@ -356,7 +362,7 @@ fn run_with_context(
             if tool_name.is_some() {
                 extras.push("[name]");
             }
-            if grep.is_some() {
+            if !grep.is_empty() {
                 extras.push("--grep");
             }
             if errors_only {
@@ -420,7 +426,7 @@ fn run_with_fields(
     where_clause: &str,
     params: &[&dyn duckdb::types::ToSql],
     field_list: &[&str],
-    errors_only: bool,
+    needs_results_join: bool,
     format: &OutputFormat,
     limit: usize,
     offset: usize,
@@ -436,13 +442,9 @@ fn run_with_fields(
     let limit_clause = super::limit_clause(limit);
     let offset_clause = super::offset_clause(offset);
 
-    let join_clause = if errors_only {
+    // is_error/content filters (if any) are already embedded in where_clause by the caller.
+    let join_clause = if needs_results_join {
         "JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id"
-    } else {
-        ""
-    };
-    let error_filter = if errors_only {
-        "AND tr.is_error = true"
     } else {
         ""
     };
@@ -454,7 +456,6 @@ fn run_with_fields(
              FROM tool_calls tc
              {join_clause}
              WHERE {where_clause}
-             {error_filter}
              ORDER BY tc.timestamp DESC
              {limit_clause}
              {offset_clause}"
@@ -468,7 +469,6 @@ fn run_with_fields(
          FROM tool_calls tc
          {join_clause}
          WHERE {where_clause}
-         {error_filter}
          ORDER BY tc.timestamp DESC
          {limit_clause}
          {offset_clause}"
@@ -496,8 +496,8 @@ fn run_with_fields(
             super::print_session_not_found(session);
         } else {
             let mut extras: Vec<&str> = Vec::new();
-            if errors_only {
-                extras.push("--errors");
+            if needs_results_join {
+                extras.push("--errors/--result-grep");
             }
             super::print_no_results(scope, &extras);
         }
@@ -511,16 +511,12 @@ fn run_with_fields(
 
     super::print_truncation_hint(
         conn,
-        if errors_only {
+        if needs_results_join {
             "tool_calls tc JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id"
         } else {
             "tool_calls tc"
         },
-        &if errors_only {
-            format!("{where_clause} AND tr.is_error = true")
-        } else {
-            where_clause.to_string()
-        },
+        where_clause,
         params,
         rows.len(),
         limit,
@@ -534,7 +530,8 @@ fn run_count_by(
     conn: &Connection,
     scope: &QueryScope,
     tool_name: Option<&str>,
-    grep: Option<&str>,
+    grep: &[String],
+    result_grep: &[String],
     errors_only: bool,
     column: &str,
     format: &OutputFormat,
@@ -568,19 +565,23 @@ fn run_count_by(
         params.push(Box::new(name.to_string()));
     }
 
-    if let Some(pattern) = grep {
-        conditions.push("CAST(tc.input AS VARCHAR) ILIKE ?".to_string());
-        params.push(Box::new(format!("%{pattern}%")));
+    if let Some(clause) = super::grep_where("CAST(tc.input AS VARCHAR)", grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(grep));
+    }
+
+    if errors_only {
+        conditions.push("tr.is_error = true".to_string());
+    }
+
+    if let Some(clause) = super::grep_where("tr.content", result_grep) {
+        conditions.push(clause);
+        params.extend(super::grep_params(result_grep));
     }
 
     let where_clause = conditions.join(" AND ");
-    let join_clause = if errors_only {
+    let join_clause = if errors_only || !result_grep.is_empty() {
         "JOIN tool_results tr ON tc.tool_use_id = tr.tool_use_id"
-    } else {
-        ""
-    };
-    let error_filter = if errors_only {
-        "AND tr.is_error = true"
     } else {
         ""
     };
@@ -590,7 +591,6 @@ fn run_count_by(
          FROM tool_calls tc
          {join_clause}
          WHERE {where_clause}
-         {error_filter}
          GROUP BY tc.{column}
          ORDER BY count DESC"
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,9 @@ struct Cli {
 enum Command {
     /// List sessions
     Sessions {
-        /// Filter sessions by content
+        /// Filter sessions by content (repeatable; matches any pattern, e.g. --grep a --grep b)
         #[arg(long)]
-        grep: Option<String>,
+        grep: Vec<String>,
 
         /// Extract specific columns (comma-separated) [valid: session_id, project, started_at, ended_at, message_count, tool_call_count, user_message_count, first_user_message]
         #[arg(long, value_delimiter = ',')]
@@ -96,9 +96,14 @@ enum Command {
         /// Filter to a specific tool name (run 'cq tools' to see available names)
         name: Option<String>,
 
-        /// Filter tool inputs by content
+        /// Filter tool inputs by content (repeatable; matches any pattern, e.g. --grep a --grep b)
         #[arg(long)]
-        grep: Option<String>,
+        grep: Vec<String>,
+
+        /// Filter tool results by content (repeatable; matches any pattern). Searches
+        /// tool_results.content, unlike --grep which searches the tool_calls input
+        #[arg(long = "result-grep")]
+        result_grep: Vec<String>,
 
         /// Show only tool calls that returned errors
         #[arg(long)]
@@ -129,9 +134,9 @@ enum Command {
         /// Filter to a specific hook event (run 'cq hooks' to see available events)
         event: Option<String>,
 
-        /// Filter hook event content by text
+        /// Filter hook event content by text (repeatable; matches any pattern, e.g. --grep a --grep b)
         #[arg(long)]
-        grep: Option<String>,
+        grep: Vec<String>,
 
         /// Aggregate rows into counts by column [valid: hook_event, hook_name, session, project]
         #[arg(long = "count-by")]
@@ -143,9 +148,9 @@ enum Command {
         #[arg(long = "type", name = "type")]
         msg_type: Option<String>,
 
-        /// Filter messages by content
+        /// Filter messages by content (repeatable; matches any pattern, e.g. --grep a --grep b)
         #[arg(long)]
-        grep: Option<String>,
+        grep: Vec<String>,
 
         /// Extract specific columns (comma-separated) [valid: session_id, project, type, timestamp, text, model, tool_count]
         #[arg(long, value_delimiter = ',')]
@@ -347,7 +352,7 @@ fn main() -> Result<()> {
             sessions::run(
                 &conn,
                 &scope,
-                grep.as_deref(),
+                &grep,
                 field_refs.as_deref(),
                 count_by.as_deref(),
                 &format,
@@ -360,6 +365,7 @@ fn main() -> Result<()> {
         Command::Tools {
             name,
             grep,
+            result_grep,
             errors,
             fields,
             count_by,
@@ -375,7 +381,8 @@ fn main() -> Result<()> {
                 &conn,
                 &scope,
                 name.as_deref(),
-                grep.as_deref(),
+                &grep,
+                &result_grep,
                 errors,
                 field_refs.as_deref(),
                 count_by.as_deref(),
@@ -395,7 +402,7 @@ fn main() -> Result<()> {
                 &conn,
                 &scope,
                 event.as_deref(),
-                grep.as_deref(),
+                &grep,
                 count_by.as_deref(),
                 &format,
                 cli.limit,
@@ -420,7 +427,7 @@ fn main() -> Result<()> {
                 &conn,
                 &scope,
                 msg_type.as_deref(),
-                grep.as_deref(),
+                &grep,
                 field_refs.as_deref(),
                 count_by.as_deref(),
                 ctx,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1124,6 +1124,147 @@ fn tools_count_by_with_filter() {
 }
 
 #[test]
+fn tools_grep_multiple_patterns_matches_any() {
+    let env = setup_env(&["simple_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args(["tools", "--grep", "zzz-no-match", "--grep", "ls"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Bash"),
+        "Second --grep pattern should still match, got: {stdout}"
+    );
+}
+
+#[test]
+fn tools_result_grep_filters_by_result_content() {
+    let env = setup_env(&["simple_session.jsonl", "error_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args(["tools", "--result-grep", "E0308"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("sess-003"),
+        "Should show the session whose tool result matched, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("sess-001"),
+        "Should not show the session with no matching result, got: {stdout}"
+    );
+}
+
+#[test]
+fn tools_result_grep_ands_with_errors() {
+    let env = setup_env(&["error_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args(["tools", "--errors", "--result-grep", "no-such-pattern"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No results"),
+        "--errors and --result-grep should AND together, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn tools_result_grep_conflicts_with_context() {
+    let env = setup_env(&["error_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args(["tools", "--result-grep", "E0308", "-C", "1"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--result-grep"),
+        "Should name the conflicting flag, got: {stderr}"
+    );
+}
+
+#[test]
+fn messages_grep_multiple_patterns_matches_any() {
+    let env = setup_env(&["simple_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args([
+            "messages",
+            "--grep",
+            "zzz-no-match",
+            "--grep",
+            "list the files",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("list the files"),
+        "Second --grep pattern should still match, got: {stdout}"
+    );
+}
+
+#[test]
+fn sessions_grep_multiple_patterns_matches_any() {
+    let env = setup_env(&["simple_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args([
+            "sessions",
+            "--grep",
+            "zzz-no-match",
+            "--grep",
+            "list the files",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("list the files"),
+        "Second --grep pattern should still match, got: {stdout}"
+    );
+}
+
+#[test]
+fn hooks_grep_multiple_patterns_matches_any() {
+    let env = setup_env(&["hook_events_session.jsonl"]);
+    let output = cq_cmd(&env)
+        .args(["hooks", "--grep", "zzz-no-match", "--grep", "superpowers"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("You have superpowers."),
+        "Second --grep pattern should still match, got: {stdout}"
+    );
+}
+
+#[test]
 fn messages_count_by_type() {
     let env = setup_env(&["simple_session.jsonl"]);
     let output = cq_cmd(&env)


### PR DESCRIPTION
## Summary

- `--grep` now accepts multiple occurrences with OR semantics (`--grep foo --grep bar` matches either), on `sessions`, `tools`, `hooks`, and `messages`. Previously a second `--grep` was a hard clap error, forcing a fallback to raw `cq sql` for any multi-term search.
- Added `tools --result-grep`, which searches `tool_results.content` (the actual output/error text). There was previously no way to search tool result content outside raw SQL with a `tool_calls JOIN tool_results` query. Composes with `--errors` via AND.
- Docs: `docs/cli-ux-conventions.md` gets a new "Repeatable filters" section; SKILL.md documents both new flags plus a GROUP BY footgun (aliasing a JSON-extracted field to a name that collides with a real view column, e.g. `agent_type`, makes DuckDB resolve `GROUP BY` to the real column instead of the alias).

Found by querying cq's own usage across recent sessions: most real investigative work (error/incident triage especially) was falling back to raw SQL specifically because these two gaps existed, not because raw SQL was genuinely needed.

## Test plan

- `cargo test` (all 112 tests pass, including 6 new integration tests covering multi-grep OR semantics and `--result-grep`, including its AND-with-`--errors` and conflict-with-context-flags behavior)
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` both clean
