### PR TITLE
feat: add Codex session support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,11 +5,11 @@ cq queries AI coding-session transcripts with SQL. It indexes transcripts into a
 ## Language
 
 **Harness**:
-The tool that produced the transcripts — Claude Code, opencode. Distinct harnesses store transcripts in fundamentally different shapes (Claude Code: a tree of JSONL files; opencode: one append-only SQLite DB).
+The tool that produced the transcripts — Claude Code, Codex, opencode. Distinct harnesses store transcripts in fundamentally different shapes (Claude Code and Codex: trees of JSONL files; opencode: one append-only SQLite DB).
 _Avoid_: "source" for this meaning (see below), "client", "agent".
 
 **Provider**:
-The cq component that knows how to read one **Harness**'s storage. `ClaudeProvider` exists today; `OpenCodeProvider` is planned. Modeled by the `TranscriptProvider` trait, though the runtime path does not yet dispatch through it polymorphically.
+The cq component that knows how to read one **Harness**'s storage. `ClaudeProvider` and `CodexProvider` exist today; `OpenCodeProvider` is planned. Modeled by the `TranscriptProvider` trait.
 _Avoid_: "adapter", "backend".
 
 **Source**:
@@ -20,8 +20,8 @@ _Avoid_: using "source" to mean a different harness.
 
 - A **Harness** is read by exactly one **Provider**.
 - The Claude **Provider** spans one or more **Sources** (main + cenv envs); `--source` scopes within it.
-- The opencode **Provider** has no **Sources** in the current sense — its storage is a single SQLite DB, not a directory of JSONL roots.
-- The cq views carry two distinct columns: `harness` is the harness/provider tag (`'claude'` / `'opencode'`), and `source` is the within-Claude root name that the `--source` flag selects (`main` + cenv envs).
+- The Codex and opencode **Providers** have no **Sources** in the current sense — Codex has one date-organized JSONL root and opencode has one SQLite DB.
+- The cq views carry two distinct columns: `harness` is the harness/provider tag (`'claude'` / `'codex'` / `'opencode'`), and `source` is the within-Claude root name that the `--source` flag selects (`main` + cenv envs).
 
 ## Flagged ambiguities
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ total_sessions  used_skill  bypassed
 
 ---
 
-**TITLE CARD:** SQL for your Claude Code sessions.
+**TITLE CARD:** SQL for your AI coding sessions.
 
-cq indexes Claude Code's JSONL session transcripts into a local [DuckDB](https://duckdb.org/) cache at `~/.cache/cq/` and gives you SQL views to query against. Incremental sync keeps it fresh on each run, so you only pay the full-parse cost once. Built-in commands handle the common stuff, and `cq sql` lets you run whatever you want.
+cq indexes Claude Code and Codex JSONL session transcripts into a local [DuckDB](https://duckdb.org/) cache at `~/.cache/cq/` and gives you SQL views to query against. Incremental sync keeps it fresh on each run, so you only pay the full-parse cost once. Built-in commands handle the common stuff, and `cq sql` lets you run whatever you want.
 
 ## Install
 
@@ -110,7 +110,7 @@ Run `cq schema --examples` for a query cookbook.
 | `-B N` | | Show N messages before each match (messages, tools) |
 | `-C N` | | Shorthand for `-A N -B N` (messages, tools) |
 
-## Sources
+## Claude sources
 
 cq indexes multiple transcript **sources**: the main config dir (`~/.claude/projects`, or `$CQ_PROJECTS_DIR`) plus every cenv env's `projects/` (discovered under `$CENV_BASE`, default `~/.local/share/cenv`). A cenv env is one kind of source; cq never shells out to cenv.
 
@@ -122,6 +122,10 @@ By default cq scopes to the **active** source (the one matching `$CLAUDE_CONFIG_
 | `--source <name>` | Target one source by name (e.g. `main`, or a cenv env name) |
 | `--all` | Span all sources |
 
+## Codex sessions
+
+Codex transcripts are discovered recursively from `~/.codex/sessions/`. Set `CQ_CODEX_SESSIONS_DIR` to point cq at a different session root. Codex rows have `harness = 'codex'` and no `source`: `--source` intentionally scopes only Claude's config roots.
+
 ## Views
 
 Five SQL views, all queryable with `cq sql`:
@@ -132,7 +136,7 @@ Five SQL views, all queryable with `cq sql`:
 - **tool_results** - one row per tool response, with an error flag
 - **hook_events** - one row per hook injection - SessionStart context, PreToolUse/PostToolUse output - fanned out per plugin for `hook_additional_context` records
 
-Subagent activity is indexed too: `messages`, `tool_calls`, and `tool_results` carry `is_sidechain`, `agent_id`, `agent_type`, and `workflow_id` so you can include, exclude, or focus subagents. `cq sessions` stays main-loop-only.
+Every view includes a `harness` column (`claude` or `codex`). Subagent activity is indexed for Claude Code: `messages`, `tool_calls`, and `tool_results` carry `is_sidechain`, `agent_id`, `agent_type`, and `workflow_id` so you can include, exclude, or focus subagents. `cq sessions` stays main-loop-only.
 
 Run `cq schema` for full column details.
 

--- a/docs/codex-session-storage.md
+++ b/docs/codex-session-storage.md
@@ -1,0 +1,35 @@
+# Codex session storage
+
+Codex writes one JSONL rollout transcript per session under `~/.codex/sessions/`,
+organized by date. cq discovers those files recursively; set
+`CQ_CODEX_SESSIONS_DIR` to use a different root.
+
+Each file combines session metadata with response items:
+
+- `session_meta` supplies the session id and working directory.
+- `response_item.message` supplies user and assistant messages.
+- `response_item.function_call` and `response_item.custom_tool_call` supply tool calls.
+- Their corresponding `*_output` records supply tool results, joined by `call_id`.
+- `turn_context` supplies the current model for messages.
+
+Codex rows are stored in cq's normal JSONL cache and exposed with
+`harness = 'codex'`. They have no `source`, because `source` identifies only
+Claude config roots. `--source` therefore never excludes Codex rows.
+
+Codex does not currently map hook events or collaboration/subagent state into
+cq's Claude-oriented columns. Those views remain empty or `NULL` for Codex
+until a stable mapping is established.
+
+## Fixture capture
+
+`tests/fixtures/codex_session.jsonl` is a redacted fixture derived from a
+controlled `codex exec` session. The capture ran in a disposable directory
+with a read-only sandbox and a prompt limited to `pwd` and fixed `printf`
+output. The committed fixture preserves the observed record families,
+including `event_msg`, developer messages, reasoning, custom tool calls, and
+world state, while replacing IDs, timestamps, paths, instructions, and model
+contents with safe values.
+
+Capture a new fixture only in a disposable directory with fixed prompts and
+outputs. Do not commit an unredacted session file: session metadata and
+developer messages can contain local paths, configuration, or private context.

--- a/src/codex_provider.rs
+++ b/src/codex_provider.rs
@@ -1,0 +1,192 @@
+use crate::provider::{ProjectInfo, TranscriptProvider, View};
+use crate::scope::QueryScope;
+use crate::views;
+use anyhow::{Context, Result};
+use duckdb::Connection;
+use std::path::{Path, PathBuf};
+
+/// Reads the JSONL rollout transcripts written by Codex. The root can be
+/// overridden for testing or a nonstandard Codex installation with
+/// `CQ_CODEX_SESSIONS_DIR`.
+pub struct CodexProvider {
+    sessions_dir: PathBuf,
+}
+
+impl CodexProvider {
+    pub fn new() -> Result<Self> {
+        let sessions_dir = match std::env::var("CQ_CODEX_SESSIONS_DIR") {
+            Ok(dir) => PathBuf::from(dir),
+            Err(_) => dirs::home_dir()
+                .context("Could not determine home directory")?
+                .join(".codex")
+                .join("sessions"),
+        };
+        Ok(Self { sessions_dir })
+    }
+
+    pub fn with_sessions_dir(sessions_dir: PathBuf) -> Self {
+        Self { sessions_dir }
+    }
+
+    pub fn sessions_dir(&self) -> &Path {
+        &self.sessions_dir
+    }
+}
+
+impl TranscriptProvider for CodexProvider {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn discover_files(&self, _scope: &QueryScope) -> Result<Vec<PathBuf>> {
+        let mut files = Vec::new();
+        collect_jsonl_paths(&self.sessions_dir, &mut files)?;
+        Ok(files)
+    }
+
+    fn register_views(&self, _conn: &Connection, _files: &[PathBuf]) -> Result<()> {
+        // Production views are composed in db::setup_connection over the
+        // persistent raw_records cache. This method remains for trait symmetry.
+        Ok(())
+    }
+
+    fn list_projects(&self) -> Result<Vec<ProjectInfo>> {
+        Ok(Vec::new())
+    }
+
+    fn prepare(&self, _conn: &Connection) -> Result<bool> {
+        Ok(self.sessions_dir.is_dir())
+    }
+
+    fn contribute_view_sql(&self, view: View) -> Option<String> {
+        match view {
+            View::Messages => Some(views::codex_messages_sql()),
+            View::ToolCalls => Some(views::codex_tool_calls_sql()),
+            View::ToolResults => Some(views::codex_tool_results_sql()),
+            View::HookEvents => views::codex_hook_events_sql(),
+            View::Sessions => Some(views::codex_sessions_sql()),
+        }
+    }
+}
+
+fn collect_jsonl_paths(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            collect_jsonl_paths(&path, files)?;
+        } else if path.extension().is_some_and(|ext| ext == "jsonl") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache;
+    use crate::db::SyncMode;
+    use crate::sync_scope::SyncScope;
+    use crate::views;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discovers_rollout_files_recursively() {
+        let root = TempDir::new().unwrap();
+        let nested = root.path().join("2026/08/26");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("rollout-a.jsonl"), "{}\n").unwrap();
+        std::fs::write(nested.join("notes.txt"), "x").unwrap();
+
+        let provider = CodexProvider::with_sessions_dir(root.path().to_path_buf());
+        let files = provider
+            .discover_files(&QueryScope::new(None, None, None))
+            .unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].ends_with("rollout-a.jsonl"));
+    }
+
+    #[test]
+    fn maps_codex_records_to_cq_views() {
+        let sessions = TempDir::new().unwrap();
+        let rollout_dir = sessions.path().join("2026/08/26");
+        std::fs::create_dir_all(&rollout_dir).unwrap();
+        let fixture =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/codex_session.jsonl");
+        std::fs::copy(&fixture, rollout_dir.join("rollout-session.jsonl")).unwrap();
+
+        let cache_dir = TempDir::new().unwrap();
+        let conn = cache::open(cache_dir.path(), true).unwrap();
+        crate::indexer::sync_sources(
+            &conn,
+            &[("codex".to_string(), sessions.path().to_path_buf())],
+            SyncMode::Force,
+            SyncScope::All,
+            cache_dir.path(),
+        )
+        .unwrap();
+
+        let provider = CodexProvider::with_sessions_dir(sessions.path().to_path_buf());
+        views::compose_views(&conn, &[&provider]).unwrap();
+
+        let session_id: String = conn
+            .query_row("SELECT session_id FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(session_id, "019a1b2c-3d4e-7f80-9a0b-1c2d3e4f5a6b");
+
+        let project: String = conn
+            .query_row("SELECT project FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(project, "/Users/test/codex-project");
+
+        let model: String = conn
+            .query_row(
+                "SELECT model FROM messages WHERE uuid = 'msg-assistant-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(model, "gpt-5-codex");
+
+        let tools: i64 = conn
+            .query_row("SELECT count(*) FROM tool_calls", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(tools, 2);
+
+        let session_tools: i64 = conn
+            .query_row("SELECT tool_call_count FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(session_tools, 2);
+
+        let messages: i64 = conn
+            .query_row("SELECT count(*) FROM messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            messages, 2,
+            "developer and reasoning records are not messages"
+        );
+
+        let event_records: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM raw_records WHERE json_extract_string(json, '$.type') = 'event_msg'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(event_records, 3);
+
+        let result: String = conn
+            .query_row(
+                "SELECT content FROM tool_results WHERE tool_use_id = 'call-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(result, "Cargo.toml\\nsrc");
+    }
+}

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -75,7 +75,7 @@ pub fn run(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 
@@ -195,7 +195,7 @@ fn run_count_by(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 
@@ -273,7 +273,7 @@ fn run_summary(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 

--- a/src/commands/messages.rs
+++ b/src/commands/messages.rs
@@ -94,7 +94,7 @@ pub fn run(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 
@@ -202,7 +202,7 @@ fn run_with_context(
         scope_conditions.push("session_id = ?".to_string());
     }
     if scope.source.is_some() {
-        scope_conditions.push("source = ?".to_string());
+        scope_conditions.push(crate::scope::source_filter_sql(""));
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -315,7 +315,7 @@ fn run_with_fields(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 
@@ -378,7 +378,7 @@ fn run_count_by(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -73,7 +73,7 @@ pub fn run(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("s.source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql("s."));
         params.push(Box::new(source.clone()));
     }
 
@@ -164,7 +164,7 @@ pub fn run(
     // The CTE always groups skills by (source, project). The join key includes
     // source so a Skill call in one source can't inflate another source's count.
     let skill_cte_filter = if scope.source.is_some() {
-        "AND source = ?"
+        "AND (harness != 'claude' OR source = ?)"
     } else {
         ""
     };
@@ -291,7 +291,10 @@ fn fetch_skills(
     }
 
     let (filter_sql, params): (&str, Vec<Box<dyn duckdb::types::ToSql>>) = match source_filter {
-        Some(src) => ("AND source = ?", vec![Box::new(src.to_string())]),
+        Some(src) => (
+            "AND (harness != 'claude' OR source = ?)",
+            vec![Box::new(src.to_string())],
+        ),
         None => ("", vec![]),
     };
 

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -133,7 +133,7 @@ pub fn run(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 
@@ -245,7 +245,7 @@ fn run_with_fields(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 
@@ -302,7 +302,7 @@ fn run_count_by(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 

--- a/src/commands/tools.rs
+++ b/src/commands/tools.rs
@@ -126,7 +126,7 @@ pub fn run(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("tc.source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql("tc."));
         params.push(Box::new(source.clone()));
     }
 
@@ -288,7 +288,7 @@ fn run_with_context(
         scope_conditions.push("session_id = ?".to_string());
     }
     if scope.source.is_some() {
-        scope_conditions.push("source = ?".to_string());
+        scope_conditions.push(crate::scope::source_filter_sql(""));
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -307,7 +307,7 @@ fn run_with_context(
         tool_conditions.push("tc.session_id = ?".to_string());
     }
     if scope.source.is_some() {
-        tool_conditions.push("tc.source = ?".to_string());
+        tool_conditions.push(crate::scope::source_filter_sql("tc."));
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -551,7 +551,7 @@ fn run_count_by(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("tc.source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql("tc."));
         params.push(Box::new(source.clone()));
     }
 
@@ -644,7 +644,7 @@ fn run_summary(
     }
 
     if let Some(source) = &scope.source {
-        conditions.push("source = ?".to_string());
+        conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod claude_provider;
+pub mod codex_provider;
 pub mod commands;
 pub mod db;
 pub mod indexer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::io::IsTerminal;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use cq::claude_provider::ClaudeProvider;
+use cq::codex_provider::CodexProvider;
 use cq::commands::{hooks, messages, projects, schema, sessions, sql, tools};
 use cq::db;
 use cq::output::OutputFormat;
@@ -294,28 +295,36 @@ fn main() -> Result<()> {
 
     let options = db::DbOptions { sync_mode };
 
-    let sources: Vec<(String, std::path::PathBuf)> = provider
+    let mut sources: Vec<(String, std::path::PathBuf)> = provider
         .sources()
         .iter()
         .map(|s| (s.name.clone(), s.projects_dir.clone()))
         .collect();
+    let codex_provider = CodexProvider::new()?;
+    sources.push((
+        "codex".to_string(),
+        codex_provider.sessions_dir().to_path_buf(),
+    ));
 
-    let sync_scope = if cli.reindex {
-        cq::sync_scope::SyncScope::All
-    } else if let Some(ref p) = scope.project {
-        let dirs = provider.project_dirs_for_query(p);
-        if dirs.is_empty() {
+    let sync_scope =
+        if cli.reindex || (scope.project.is_some() && codex_provider.sessions_dir().is_dir()) {
             cq::sync_scope::SyncScope::All
+        } else if let Some(ref p) = scope.project {
+            let dirs = provider.project_dirs_for_query(p);
+            if dirs.is_empty() {
+                cq::sync_scope::SyncScope::All
+            } else {
+                cq::sync_scope::SyncScope::Projects(dirs)
+            }
         } else {
-            cq::sync_scope::SyncScope::Projects(dirs)
-        }
-    } else {
-        cq::sync_scope::SyncScope::All
-    };
+            cq::sync_scope::SyncScope::All
+        };
 
     let start = std::time::Instant::now();
-    let providers: Vec<Box<dyn cq::provider::TranscriptProvider>> =
-        vec![Box::new(cq::claude_provider::ClaudeProvider::new()?)];
+    let providers: Vec<Box<dyn cq::provider::TranscriptProvider>> = vec![
+        Box::new(cq::claude_provider::ClaudeProvider::new()?),
+        Box::new(codex_provider),
+    ];
     let db_setup = db::setup_connection(&providers, &sources, &options, sync_scope)?;
     let elapsed = start.elapsed();
     if db_setup.lock_busy {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -82,6 +82,13 @@ impl QueryScope {
     }
 }
 
+/// SQL predicate for CQ's Claude-only `--source` dimension. Other harnesses
+/// do not have Claude sources, so they remain in scope when a source is chosen.
+/// `prefix` is an optional relation prefix such as `"tc."`.
+pub fn source_filter_sql(prefix: &str) -> String {
+    format!("({prefix}harness != 'claude' OR {prefix}source = ?)")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/views.rs
+++ b/src/views.rs
@@ -318,6 +318,214 @@ pub fn claude_sessions_sql() -> String {
         GROUP BY session_id".to_string()
 }
 
+/// The Codex `messages` view body. Codex keeps session metadata and response
+/// items in one JSONL file. Message content is an array of input/output text
+/// items, so each response item becomes one cq message row.
+pub fn codex_messages_sql() -> String {
+    "WITH codex_records AS (
+        SELECT source_file, json
+        FROM raw_records
+        WHERE json_extract_string(json, '$.type') = 'response_item'
+    ),
+    session_meta AS (
+        SELECT source_file,
+               COALESCE(
+                   json_extract_string(json, '$.payload.id'),
+                   json_extract_string(json, '$.payload.session_id')
+               ) AS session_id,
+               json_extract_string(json, '$.payload.cwd') AS project
+        FROM raw_records
+        WHERE json_extract_string(json, '$.type') = 'session_meta'
+    )
+    SELECT
+        meta.session_id,
+        meta.project,
+        NULL::VARCHAR AS source,
+        'codex' AS harness,
+        json_extract_string(record.json, '$.payload.id') AS uuid,
+        NULL::VARCHAR AS parent_uuid,
+        json_extract_string(record.json, '$.payload.role') AS type,
+        json_extract_string(record.json, '$.timestamp') AS timestamp,
+        (SELECT string_agg(json_extract_string(item, '$.text'), '')
+         FROM (
+             SELECT UNNEST(CAST(json_extract(record.json, '$.payload.content') AS JSON[])) AS item
+         )
+         WHERE json_extract_string(item, '$.type') IN ('input_text', 'output_text', 'text')) AS text,
+        CAST(0 AS BIGINT) AS tool_count,
+        (SELECT json_extract_string(context.json, '$.payload.model')
+         FROM raw_records context
+         WHERE context.source_file = record.source_file
+           AND json_extract_string(context.json, '$.type') = 'turn_context'
+         ORDER BY CAST(json_extract(context.json, '$.ordinal') AS BIGINT) DESC
+         LIMIT 1) AS model,
+        NULL::VARCHAR AS agent_id,
+        false AS is_sidechain,
+        NULL::VARCHAR AS agent_type,
+        NULL::VARCHAR AS workflow_id
+    FROM codex_records record
+    JOIN session_meta meta USING (source_file)
+    WHERE json_extract_string(record.json, '$.payload.type') = 'message'
+      AND json_extract_string(record.json, '$.payload.role') IN ('user', 'assistant')".to_string()
+}
+
+/// The Codex `tool_calls` view body. Both built-in function calls and Codex
+/// custom-tool calls have stable call IDs and JSON-string inputs.
+pub fn codex_tool_calls_sql() -> String {
+    "WITH session_meta AS (
+        SELECT source_file,
+               COALESCE(
+                   json_extract_string(json, '$.payload.id'),
+                   json_extract_string(json, '$.payload.session_id')
+               ) AS session_id,
+               json_extract_string(json, '$.payload.cwd') AS project
+        FROM raw_records
+        WHERE json_extract_string(json, '$.type') = 'session_meta'
+    )
+    SELECT
+        meta.session_id,
+        meta.project,
+        NULL::VARCHAR AS source,
+        'codex' AS harness,
+        json_extract_string(record.json, '$.payload.id') AS message_uuid,
+        json_extract_string(record.json, '$.payload.call_id') AS tool_use_id,
+        json_extract_string(record.json, '$.payload.name') AS name,
+        TRY_CAST(json_extract_string(record.json, '$.payload.arguments') AS JSON) AS input,
+        json_extract_string(record.json, '$.timestamp') AS timestamp,
+        NULL::VARCHAR AS agent_id,
+        false AS is_sidechain,
+        NULL::VARCHAR AS agent_type,
+        NULL::VARCHAR AS workflow_id
+    FROM raw_records record
+    JOIN session_meta meta USING (source_file)
+    WHERE json_extract_string(record.json, '$.type') = 'response_item'
+      AND json_extract_string(record.json, '$.payload.type') = 'function_call'
+    UNION ALL
+    SELECT
+        meta.session_id,
+        meta.project,
+        NULL::VARCHAR AS source,
+        'codex' AS harness,
+        json_extract_string(record.json, '$.payload.id') AS message_uuid,
+        json_extract_string(record.json, '$.payload.call_id') AS tool_use_id,
+        json_extract_string(record.json, '$.payload.name') AS name,
+        TRY_CAST(json_extract_string(record.json, '$.payload.input') AS JSON) AS input,
+        json_extract_string(record.json, '$.timestamp') AS timestamp,
+        NULL::VARCHAR AS agent_id,
+        false AS is_sidechain,
+        NULL::VARCHAR AS agent_type,
+        NULL::VARCHAR AS workflow_id
+    FROM raw_records record
+    JOIN session_meta meta USING (source_file)
+    WHERE json_extract_string(record.json, '$.type') = 'response_item'
+      AND json_extract_string(record.json, '$.payload.type') = 'custom_tool_call'"
+        .to_string()
+}
+
+/// The Codex `tool_results` view body. Codex records outputs separately from
+/// calls but uses the same `call_id` join key. Output may be a string or JSON
+/// array; keeping the latter as JSON text preserves all returned blocks.
+pub fn codex_tool_results_sql() -> String {
+    "WITH session_meta AS (
+        SELECT source_file,
+               COALESCE(
+                   json_extract_string(json, '$.payload.id'),
+                   json_extract_string(json, '$.payload.session_id')
+               ) AS session_id,
+               json_extract_string(json, '$.payload.cwd') AS project
+        FROM raw_records
+        WHERE json_extract_string(json, '$.type') = 'session_meta'
+    )
+    SELECT
+        meta.session_id,
+        meta.project,
+        NULL::VARCHAR AS source,
+        'codex' AS harness,
+        json_extract_string(record.json, '$.payload.call_id') AS tool_use_id,
+        false AS is_error,
+        json_extract_string(record.json, '$.payload.output') AS content,
+        NULL::VARCHAR AS agent_id,
+        false AS is_sidechain,
+        NULL::VARCHAR AS agent_type,
+        NULL::VARCHAR AS workflow_id
+    FROM raw_records record
+    JOIN session_meta meta USING (source_file)
+    WHERE json_extract_string(record.json, '$.type') = 'response_item'
+      AND json_extract_string(record.json, '$.payload.type') = 'function_call_output'
+    UNION ALL
+    SELECT
+        meta.session_id,
+        meta.project,
+        NULL::VARCHAR AS source,
+        'codex' AS harness,
+        json_extract_string(record.json, '$.payload.call_id') AS tool_use_id,
+        false AS is_error,
+        CAST(json_extract(record.json, '$.payload.output') AS VARCHAR) AS content,
+        NULL::VARCHAR AS agent_id,
+        false AS is_sidechain,
+        NULL::VARCHAR AS agent_type,
+        NULL::VARCHAR AS workflow_id
+    FROM raw_records record
+    JOIN session_meta meta USING (source_file)
+    WHERE json_extract_string(record.json, '$.type') = 'response_item'
+      AND json_extract_string(record.json, '$.payload.type') = 'custom_tool_call_output'"
+        .to_string()
+}
+
+/// Codex currently does not record Claude-compatible hook events.
+pub fn codex_hook_events_sql() -> Option<String> {
+    None
+}
+
+/// The Codex `sessions` view body is anchored on `session_meta`, so even a
+/// freshly-created session with no messages remains queryable.
+pub fn codex_sessions_sql() -> String {
+    "WITH session_meta AS (
+        SELECT source_file,
+               COALESCE(
+                   json_extract_string(json, '$.payload.id'),
+                   json_extract_string(json, '$.payload.session_id')
+               ) AS session_id,
+               json_extract_string(json, '$.payload.cwd') AS project,
+               json_extract_string(json, '$.timestamp') AS started_at
+        FROM raw_records
+        WHERE json_extract_string(json, '$.type') = 'session_meta'
+    ),
+    tool_counts AS (
+        SELECT session_id, COUNT(*) AS tool_call_count
+        FROM tool_calls
+        WHERE harness = 'codex'
+        GROUP BY session_id
+    )
+    SELECT
+        meta.session_id,
+        meta.project,
+        NULL::VARCHAR AS source,
+        'codex' AS harness,
+        meta.started_at,
+        COALESCE(MAX(message.timestamp), meta.started_at) AS ended_at,
+        COUNT(message.uuid) AS message_count,
+        CAST(COALESCE(MAX(tool_counts.tool_call_count), 0) AS BIGINT) AS tool_call_count,
+        COUNT(message.uuid) FILTER (WHERE message.type = 'user') AS user_message_count,
+        CAST(0 AS BIGINT) AS subagent_count,
+        (SELECT text FROM messages first_message
+         WHERE first_message.session_id = meta.session_id
+           AND first_message.harness = 'codex'
+           AND first_message.type = 'user'
+           AND first_message.text IS NOT NULL
+           AND first_message.text != ''
+           AND first_message.text NOT LIKE '<environment_context>%'
+         ORDER BY first_message.timestamp
+         LIMIT 1) AS first_user_message
+    FROM session_meta meta
+    LEFT JOIN messages message
+      ON message.session_id = meta.session_id
+     AND message.harness = 'codex'
+    LEFT JOIN tool_counts
+      ON tool_counts.session_id = meta.session_id
+    GROUP BY meta.session_id, meta.project, meta.started_at"
+        .to_string()
+}
+
 /// The empty-view body (correct schema, zero rows) for one view. Used when no
 /// active provider contributes to that view.
 fn empty_view_sql(view: View) -> &'static str {

--- a/tests/fixtures/codex_session.jsonl
+++ b/tests/fixtures/codex_session.jsonl
@@ -1,0 +1,14 @@
+{"timestamp":"2026-08-26T14:00:00.000Z","type":"session_meta","payload":{"id":"019a1b2c-3d4e-7f80-9a0b-1c2d3e4f5a6b","session_id":"019a1b2c-3d4e-7f80-9a0b-1c2d3e4f5a6b","cwd":"/Users/test/codex-project","model_provider":"openai"}}
+{"timestamp":"2026-08-26T14:00:00.100Z","type":"turn_context","payload":{"turn_id":"turn-1","cwd":"/Users/test/codex-project","model":"gpt-5-codex"}}
+{"timestamp":"2026-08-26T14:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1","started_at":"2026-08-26T14:00:00.200Z","model_context_window":272000,"collaboration_mode_kind":"default"}}
+{"timestamp":"2026-08-26T14:00:00.300Z","type":"response_item","payload":{"type":"message","id":"msg-developer-1","role":"developer","content":[{"type":"input_text","text":"redacted developer instructions"}]}}
+{"timestamp":"2026-08-26T14:00:01.000Z","type":"response_item","payload":{"type":"message","id":"msg-user-1","role":"user","content":[{"type":"input_text","text":"list the files"}]}}
+{"timestamp":"2026-08-26T14:00:01.100Z","type":"response_item","payload":{"type":"reasoning","id":"reasoning-1","encrypted_content":"redacted","summary":[]}}
+{"timestamp":"2026-08-26T14:00:02.000Z","type":"response_item","payload":{"type":"function_call","id":"fc-1","call_id":"call-1","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"}}
+{"timestamp":"2026-08-26T14:00:03.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"Cargo.toml\\nsrc"}}
+{"timestamp":"2026-08-26T14:00:04.000Z","type":"response_item","payload":{"type":"message","id":"msg-assistant-1","role":"assistant","content":[{"type":"output_text","text":"The project has a Cargo manifest and source directory."}]}}
+{"timestamp":"2026-08-26T14:00:05.000Z","type":"response_item","payload":{"type":"custom_tool_call","id":"ctc-1","call_id":"call-2","name":"plugin_lookup","input":"{\"query\":\"git\"}"}}
+{"timestamp":"2026-08-26T14:00:06.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-2","output":[{"type":"text","text":"No plugin found"}]}}
+{"timestamp":"2026-08-26T14:00:06.100Z","type":"event_msg","payload":{"type":"item_completed","thread_id":"019a1b2c-3d4e-7f80-9a0b-1c2d3e4f5a6b","turn_id":"turn-1","started_at_ms":1787752806100,"completed_at_ms":1787752806100,"item":{"type":"CommandExecution"}}}
+{"timestamp":"2026-08-26T14:00:06.200Z","type":"world_state","payload":{"state":"redacted","full":false}}
+{"timestamp":"2026-08-26T14:00:06.300Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","started_at":"2026-08-26T14:00:00.200Z","completed_at":"2026-08-26T14:00:06.300Z","duration_ms":6100,"time_to_first_token_ms":100,"last_agent_message":"fixture complete"}}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -11,6 +11,7 @@ fn fixture_path(name: &str) -> PathBuf {
 
 struct TestEnv {
     projects: TempDir,
+    codex_sessions: TempDir,
     cache: TempDir,
 }
 
@@ -23,18 +24,36 @@ fn setup_env(fixtures: &[&str]) -> TestEnv {
         let dest = project_dir.join(fixture);
         std::fs::copy(&src, &dest).unwrap();
     }
+    let codex_sessions = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
-    TestEnv { projects, cache }
+    TestEnv {
+        projects,
+        codex_sessions,
+        cache,
+    }
 }
 
 fn cq_cmd(env: &TestEnv) -> Command {
     let mut cmd = Command::cargo_bin("cq").unwrap();
     cmd.env("CQ_PROJECTS_DIR", env.projects.path());
     cmd.env("CQ_CACHE_DIR", env.cache.path());
+    cmd.env("CQ_CODEX_SESSIONS_DIR", env.codex_sessions.path());
     // Isolate from any real cenv envs on the host so only CQ_PROJECTS_DIR is indexed.
     cmd.env("CENV_BASE", env.cache.path().join("no-such-cenv-base"));
     cmd.env("NO_COLOR", "1");
     cmd
+}
+
+fn setup_codex_env() -> TestEnv {
+    let env = setup_env(&[]);
+    let rollout_dir = env.codex_sessions.path().join("2026/08/26");
+    std::fs::create_dir_all(&rollout_dir).unwrap();
+    std::fs::copy(
+        fixture_path("codex_session.jsonl"),
+        rollout_dir.join("rollout-2026-08-26T14-00-00-session.jsonl"),
+    )
+    .unwrap();
+    env
 }
 
 #[test]
@@ -102,6 +121,30 @@ fn sessions_list() {
         .assert()
         .success()
         .stdout(predicate::str::contains("sess-001"));
+}
+
+#[test]
+fn codex_sessions_and_tools_are_queryable() {
+    let env = setup_codex_env();
+
+    // The normal default source scope is Claude-only; Codex remains visible
+    // because it has no Claude source dimension.
+    cq_cmd(&env)
+        .arg("sessions")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("019a1b2c"));
+
+    cq_cmd(&env)
+        .args([
+            "sql",
+            "SELECT harness, project, count(*) AS tools FROM tool_calls GROUP BY harness, project",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("codex"))
+        .stdout(predicate::str::contains("codex-project"))
+        .stdout(predicate::str::contains("2"));
 }
 
 #[test]
@@ -215,7 +258,11 @@ fn json_output() {
 fn no_files_no_error() {
     let projects = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
-    let env = TestEnv { projects, cache };
+    let env = TestEnv {
+        projects,
+        codex_sessions: TempDir::new().unwrap(),
+        cache,
+    };
     let output = cq_cmd(&env).arg("tools").output().unwrap();
     assert!(output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -284,6 +331,10 @@ fn no_color_flag() {
     let mut cmd = Command::cargo_bin("cq").unwrap();
     cmd.env("CQ_PROJECTS_DIR", env.projects.path());
     cmd.env("CQ_CACHE_DIR", env.cache.path());
+    cmd.env(
+        "CQ_CODEX_SESSIONS_DIR",
+        env.cache.path().join("no-such-codex-sessions"),
+    );
     cmd.env("CENV_BASE", env.cache.path().join("no-such-cenv-base"));
     // Explicitly unset NO_COLOR so we're testing the flag, not the env var
     cmd.env_remove("NO_COLOR");
@@ -503,7 +554,11 @@ fn auto_scope_to_current_project() {
     )
     .unwrap();
 
-    let env = TestEnv { projects, cache };
+    let env = TestEnv {
+        projects,
+        codex_sessions: TempDir::new().unwrap(),
+        cache,
+    };
 
     // Run from "myproject" dir (matches simple_session.jsonl's cwd), should auto-scope
     let output = cq_cmd(&env)
@@ -542,7 +597,11 @@ fn auto_scope_hint_shows_path() {
     )
     .unwrap();
 
-    let env = TestEnv { projects, cache };
+    let env = TestEnv {
+        projects,
+        codex_sessions: TempDir::new().unwrap(),
+        cache,
+    };
 
     let output = cq_cmd(&env)
         .env("PWD", "/Users/test/myproject")
@@ -632,7 +691,11 @@ fn projects_always_unscoped() {
     )
     .unwrap();
 
-    let env = TestEnv { projects, cache };
+    let env = TestEnv {
+        projects,
+        codex_sessions: TempDir::new().unwrap(),
+        cache,
+    };
 
     // Run from "myproject" dir. projects should still show BOTH projects.
     let output = cq_cmd(&env)
@@ -672,7 +735,11 @@ fn all_flag_overrides_auto_scope() {
     )
     .unwrap();
 
-    let env = TestEnv { projects, cache };
+    let env = TestEnv {
+        projects,
+        codex_sessions: TempDir::new().unwrap(),
+        cache,
+    };
 
     // Run with --all from myproject dir, should show sessions from BOTH projects
     let output = cq_cmd(&env)
@@ -1368,6 +1435,7 @@ fn setup_subagent_env() -> TestEnv {
 
     TestEnv {
         projects,
+        codex_sessions: TempDir::new().unwrap(),
         cache: TempDir::new().unwrap(),
     }
 }
@@ -1543,7 +1611,16 @@ fn sessions_timeline_json() {
 
 #[test]
 fn no_reindex_skips_sync() {
+    let projects = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
     let mut cmd = Command::cargo_bin("cq").unwrap();
+    cmd.env("CQ_PROJECTS_DIR", projects.path());
+    cmd.env("CQ_CACHE_DIR", cache.path());
+    cmd.env(
+        "CQ_CODEX_SESSIONS_DIR",
+        cache.path().join("no-such-codex-sessions"),
+    );
+    cmd.env("CENV_BASE", cache.path().join("no-such-cenv-base"));
     cmd.arg("--no-reindex")
         .arg("sessions")
         .arg("--limit")
@@ -1578,7 +1655,11 @@ fn sessions_count_by_project() {
     )
     .unwrap();
 
-    let env = TestEnv { projects, cache };
+    let env = TestEnv {
+        projects,
+        codex_sessions: TempDir::new().unwrap(),
+        cache,
+    };
     let output = cq_cmd(&env)
         .args(["sessions", "--count-by", "project"])
         .output()
@@ -1944,6 +2025,10 @@ fn multi_cmd(env: &MultiSourceEnv) -> Command {
     let mut cmd = Command::cargo_bin("cq").unwrap();
     cmd.env("CQ_PROJECTS_DIR", env.projects.path());
     cmd.env("CQ_CACHE_DIR", env.cache.path());
+    cmd.env(
+        "CQ_CODEX_SESSIONS_DIR",
+        env.cache.path().join("no-such-codex-sessions"),
+    );
     cmd.env("CENV_BASE", env.cenv_base.path());
     cmd.env("NO_COLOR", "1");
     cmd


### PR DESCRIPTION
## Summary
- discover and incrementally index Codex JSONL rollout transcripts
- expose Codex messages, sessions, tool calls, and tool results alongside Claude data
- keep Claude --source scoping from hiding Codex sessions
- document configuration via CQ_CODEX_SESSIONS_DIR

## Validation
- cargo test
- manually queried the active Codex session with a temporary CQ cache