### PR TITLE
feat: scope queries to active Codex harness

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,7 @@ _Avoid_: using "source" to mean a different harness.
 - The Claude **Provider** spans one or more **Sources** (main + cenv envs); `--source` scopes within it.
 - The Codex and opencode **Providers** have no **Sources** in the current sense — Codex has one date-organized JSONL root and opencode has one SQLite DB.
 - The cq views carry two distinct columns: `harness` is the harness/provider tag (`'claude'` / `'codex'` / `'opencode'`), and `source` is the within-Claude root name that the `--source` flag selects (`main` + cenv envs).
+- `--harness` scopes across providers. In a Codex runtime, cq infers `--harness codex` for normal commands; `--all` disables that inference. `--source` remains a Claude-only dimension and cannot be combined with `--harness`.
 
 ## Flagged ambiguities
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Run `cq schema --examples` for a query cookbook.
 | `--project <name>` | `-p` | Scope to a project (substring match) |
 | `--session <id>` | `-s` | Scope to a session (UUID prefix match) |
 | `--since <duration>` | | Time filter: `7d`, `24h`, `30m` |
-| `--all` | | Show all projects (disable auto-scoping) |
+| `--all` | | Disable automatic project, source, and harness scoping |
+| `--harness <name>` | | Target one harness (`claude` or `codex`; cannot combine with `--source`) |
 | `--json` | | JSON output instead of tables |
 | `--table` | | Aligned table with headers |
 | `--no-color` | | Disable colored output |
@@ -114,7 +115,7 @@ Run `cq schema --examples` for a query cookbook.
 
 cq indexes multiple transcript **sources**: the main config dir (`~/.claude/projects`, or `$CQ_PROJECTS_DIR`) plus every cenv env's `projects/` (discovered under `$CENV_BASE`, default `~/.local/share/cenv`). A cenv env is one kind of source; cq never shells out to cenv.
 
-By default cq scopes to the **active** source (the one matching `$CLAUDE_CONFIG_DIR`, else `main`), mirroring how it auto-scopes to the current directory. Use `--all` to span every source and `--source <name>` to target one. Every row carries a `source` column; compose with `--since` to weigh results by age.
+Outside Codex, cq scopes to the **active** Claude source (the one matching `$CLAUDE_CONFIG_DIR`, else `main`), mirroring how it auto-scopes to the current directory. Use `--all` to span every source and `--source <name>` to target one. Every row carries a `source` column; compose with `--since` to weigh results by age.
 
 | Flag | What it does |
 |------|-------------|
@@ -124,7 +125,9 @@ By default cq scopes to the **active** source (the one matching `$CLAUDE_CONFIG_
 
 ## Codex sessions
 
-Codex transcripts are discovered recursively from `~/.codex/sessions/`. Set `CQ_CODEX_SESSIONS_DIR` to point cq at a different session root. Codex rows have `harness = 'codex'` and no `source`: `--source` intentionally scopes only Claude's config roots.
+Codex transcripts are discovered recursively from `~/.codex/sessions/`. Set `CQ_CODEX_SESSIONS_DIR` to point cq at a different session root. Codex rows have `harness = 'codex'` and no `source`.
+
+When cq runs inside a Codex session, it automatically scopes normal commands to `harness = 'codex'` and skips Claude's automatic source scope. Use `--all` to span harnesses, or `--harness claude` / `--harness codex` to choose one explicitly. `--source` selects Claude rows only, so it cannot be combined with `--harness`. `cq sql` is raw SQL and ignores all scope flags.
 
 ## Views
 

--- a/claude-plugin/skills/cq/SKILL.md
+++ b/claude-plugin/skills/cq/SKILL.md
@@ -24,8 +24,9 @@ user_invocable: true
 - `--project <NAME>` - Substring match on project name
 - `--session <ID>` - Session ID (full UUID required, validates format)
 - `--source <NAME>` - Scope to a named source (`main`, or a cenv env name); use `--all` to span every source. Every row carries a `source` column.
-- `--all` - Show all projects and all sources (disable auto-scoping)
-- `--since <DURATION>` - Time filter (e.g. `7d`, `24h`, `30m`); applies to `sessions`/`tools`/`messages`, not `cq sql` (raw SQL ignores scope flags)
+- `--harness <NAME>` - Scope to `claude` or `codex`; cannot combine with `--source`. In Codex, cq automatically selects `codex` unless `--all` is set.
+- `--all` - Show all projects, sources, and harnesses (disable auto-scoping)
+- `--since <DURATION>` - Time filter (e.g. `7d`, `24h`, `30m`); applies to `sessions`/`tools`/`messages`, not `cq sql` (raw SQL ignores all scope flags)
 - `--json` - Machine-readable JSON output
 - `--table` - Aligned table with header
 - `--limit <N>` - Max results (default 50, 0 for unlimited)
@@ -39,13 +40,13 @@ user_invocable: true
 
 ## View Schemas
 
-**sessions**: session_id, project, source, started_at, ended_at, message_count, tool_call_count, user_message_count, subagent_count, first_user_message (counts are main-loop only)
+**sessions**: session_id, project, source, harness, started_at, ended_at, message_count, tool_call_count, user_message_count, subagent_count, first_user_message (counts are main-loop only)
 
-**messages**: session_id, project, source, uuid, parent_uuid, type, timestamp, text, tool_count, model, agent_id, is_sidechain, agent_type, workflow_id
+**messages**: session_id, project, source, harness, uuid, parent_uuid, type, timestamp, text, tool_count, model, agent_id, is_sidechain, agent_type, workflow_id
 
-**tool_calls**: session_id, project, source, message_uuid, tool_use_id, name, input (JSON), timestamp, agent_id, is_sidechain, agent_type, workflow_id. `advisor()` invocations appear here too, with `name = 'advisor'` (they use a `server_tool_use` block under the hood, not the standard `tool_use`).
+**tool_calls**: session_id, project, source, harness, message_uuid, tool_use_id, name, input (JSON), timestamp, agent_id, is_sidechain, agent_type, workflow_id. `advisor()` invocations appear here too, with `name = 'advisor'` (they use a `server_tool_use` block under the hood, not the standard `tool_use`).
 
-**tool_results**: session_id, project, source, tool_use_id, is_error, content, agent_id, is_sidechain, agent_type, workflow_id. `advisor()` results appear here with `content` already unwrapped to the advisor's text.
+**tool_results**: session_id, project, source, harness, tool_use_id, is_error, content, agent_id, is_sidechain, agent_type, workflow_id. `advisor()` results appear here with `content` already unwrapped to the advisor's text.
 
 Subagent rows carry the parent `session_id`. Filter with `WHERE NOT is_sidechain` (main loop), `WHERE is_sidechain` (subagents), `WHERE agent_type = 'Explore'`, or `WHERE workflow_id IS NOT NULL`.
 

--- a/docs/codex-session-storage.md
+++ b/docs/codex-session-storage.md
@@ -14,7 +14,10 @@ Each file combines session metadata with response items:
 
 Codex rows are stored in cq's normal JSONL cache and exposed with
 `harness = 'codex'`. They have no `source`, because `source` identifies only
-Claude config roots. `--source` therefore never excludes Codex rows.
+Claude config roots. When cq runs inside Codex, it automatically filters normal
+commands to `harness = 'codex'` and skips Claude's automatic source selection.
+Use `--all` to span harnesses or `--harness codex` outside Codex. An explicit
+`--source` selects Claude rows and cannot be combined with `--harness`.
 
 Codex does not currently map hook events or collaboration/subagent state into
 cq's Claude-oriented columns. Those views remain empty or `NULL` for Codex

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -78,6 +78,10 @@ pub fn run(
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -198,6 +202,10 @@ fn run_count_by(
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -275,6 +283,10 @@ fn run_summary(
     if let Some(source) = &scope.source {
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
+    }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/commands/messages.rs
+++ b/src/commands/messages.rs
@@ -97,6 +97,10 @@ pub fn run(
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -203,6 +207,9 @@ fn run_with_context(
     }
     if scope.source.is_some() {
         scope_conditions.push(crate::scope::source_filter_sql(""));
+    }
+    if scope.harness.is_some() {
+        scope_conditions.push(crate::scope::harness_filter_sql(""));
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -318,6 +325,10 @@ fn run_with_fields(
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -380,6 +391,10 @@ fn run_count_by(
     if let Some(source) = &scope.source {
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
+    }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -227,6 +227,9 @@ pub fn print_no_results(scope: &crate::scope::QueryScope, extra_filters: &[&str]
     if scope.source.is_some() {
         active.push("--source".to_string());
     }
+    if scope.harness.is_some() {
+        active.push("--harness".to_string());
+    }
     for f in extra_filters {
         active.push(f.to_string());
     }
@@ -274,7 +277,7 @@ pub fn print_truncation_hint(
 
 /// Build the parameter vector corresponding to the scope WHERE clause fragments
 /// used in the `ordered` CTE and `matches_subquery`. Order matters, must match the
-/// order in which scope_conditions are pushed: project, then session, then source.
+/// order in which scope_conditions are pushed: project, session, source, harness.
 /// `since` is inlined into the SQL string so it contributes no params.
 pub fn build_scope_params(scope: &crate::scope::QueryScope) -> Vec<Box<dyn duckdb::types::ToSql>> {
     let mut params: Vec<Box<dyn duckdb::types::ToSql>> = Vec::new();
@@ -286,6 +289,9 @@ pub fn build_scope_params(scope: &crate::scope::QueryScope) -> Vec<Box<dyn duckd
     }
     if let Some(source) = &scope.source {
         params.push(Box::new(source.clone()));
+    }
+    if let Some(harness) = &scope.harness {
+        params.push(Box::new(harness.clone()));
     }
     params
 }

--- a/src/commands/projects.rs
+++ b/src/commands/projects.rs
@@ -76,6 +76,10 @@ pub fn run(
         conditions.push(crate::scope::source_filter_sql("s."));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql("s."));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -121,15 +125,23 @@ pub fn run(
 
             // Fetch skills for this (source, project): a Skill tool_call in one
             // source must not inflate another source's skill list.
-            let skill_sql = "SELECT DISTINCT json_extract_string(input, '$.skill') as skill
+            let skill_harness_filter = if scope.harness.is_some() {
+                "AND harness = ?"
+            } else {
+                ""
+            };
+            let skill_sql = format!(
+                "SELECT DISTINCT json_extract_string(input, '$.skill') as skill
                 FROM tool_calls
-                WHERE name = 'Skill' AND project = ? AND source = ?
-                ORDER BY skill";
-            let mut skill_stmt = conn.prepare(skill_sql)?;
-            let mut skill_iter = skill_stmt.query([
-                &project as &dyn duckdb::types::ToSql,
-                &source as &dyn duckdb::types::ToSql,
-            ])?;
+                WHERE name = 'Skill' AND project = ? AND source = ? {skill_harness_filter}
+                ORDER BY skill"
+            );
+            let mut skill_stmt = conn.prepare(&skill_sql)?;
+            let mut skill_params: Vec<&dyn duckdb::types::ToSql> = vec![&project, &source];
+            if let Some(harness) = &scope.harness {
+                skill_params.push(harness);
+            }
+            let mut skill_iter = skill_stmt.query(&skill_params[..])?;
             let mut skills: Vec<String> = Vec::new();
             while let Some(skill_row) = skill_iter.next()? {
                 let s = skill_row.get::<_, String>(0).unwrap_or_default();
@@ -163,11 +175,14 @@ pub fn run(
     //
     // The CTE always groups skills by (source, project). The join key includes
     // source so a Skill call in one source can't inflate another source's count.
-    let skill_cte_filter = if scope.source.is_some() {
-        "AND (harness != 'claude' OR source = ?)"
-    } else {
-        ""
-    };
+    let mut skill_cte_filters = Vec::new();
+    if scope.source.is_some() {
+        skill_cte_filters.push("AND source = ?");
+    }
+    if scope.harness.is_some() {
+        skill_cte_filters.push("AND harness = ?");
+    }
+    let skill_cte_filter = skill_cte_filters.join(" ");
 
     // Params in SQL-text order: 1) CTE source filter (if scoped), 2) outer WHERE
     // params (project ILIKE, then outer source) as already collected in `params`.
@@ -175,11 +190,17 @@ pub fn run(
     if let Some(source) = &scope.source {
         agg_params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        agg_params.push(Box::new(harness.clone()));
+    }
     if let Some(project) = &scope.project {
         agg_params.push(Box::new(format!("%{project}%")));
     }
     if let Some(source) = &scope.source {
         agg_params.push(Box::new(source.clone()));
+    }
+    if let Some(harness) = &scope.harness {
+        agg_params.push(Box::new(harness.clone()));
     }
 
     let sql = format!(
@@ -241,7 +262,12 @@ pub fn run(
             .iter()
             .map(|r| (r.source.as_str(), r.project.as_str()))
             .collect();
-        fetch_skills(conn, scope.source.as_deref(), &pairs)?
+        fetch_skills(
+            conn,
+            scope.source.as_deref(),
+            scope.harness.as_deref(),
+            &pairs,
+        )?
     } else {
         vec![]
     };
@@ -284,19 +310,24 @@ pub fn run(
 fn fetch_skills(
     conn: &Connection,
     source_filter: Option<&str>,
+    harness_filter: Option<&str>,
     pairs: &[(&str, &str)],
 ) -> Result<Vec<SkillRow>> {
     if pairs.is_empty() {
         return Ok(vec![]);
     }
 
-    let (filter_sql, params): (&str, Vec<Box<dyn duckdb::types::ToSql>>) = match source_filter {
-        Some(src) => (
-            "AND (harness != 'claude' OR source = ?)",
-            vec![Box::new(src.to_string())],
-        ),
-        None => ("", vec![]),
-    };
+    let mut filter_parts = Vec::new();
+    let mut params: Vec<Box<dyn duckdb::types::ToSql>> = Vec::new();
+    if let Some(source) = source_filter {
+        filter_parts.push("AND source = ?");
+        params.push(Box::new(source.to_string()));
+    }
+    if let Some(harness) = harness_filter {
+        filter_parts.push("AND harness = ?");
+        params.push(Box::new(harness.to_string()));
+    }
+    let filter_sql = filter_parts.join(" ");
 
     let sql = format!(
         "SELECT source, project, json_extract_string(input, '$.skill') as skill

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -31,7 +31,7 @@ const MESSAGES_SCHEMA: &str = r#"messages
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name (directory containing the JSONL file)
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   uuid                VARCHAR   Message UUID
   parent_uuid         VARCHAR   Parent message UUID
   type                VARCHAR   'user' or 'assistant'
@@ -49,7 +49,7 @@ const TOOL_CALLS_SCHEMA: &str = r#"tool_calls
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   message_uuid        VARCHAR   UUID of the containing assistant message
   tool_use_id         VARCHAR   Unique tool use ID (matches tool_results.tool_use_id)
   name                VARCHAR   Tool name (e.g. 'Bash', 'Read', 'Edit', 'Skill')
@@ -69,7 +69,7 @@ const TOOL_RESULTS_SCHEMA: &str = r#"tool_results
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   tool_use_id         VARCHAR   Matches tool_calls.tool_use_id
   is_error            BOOLEAN   true if the tool call returned an error
   content             VARCHAR   Tool result content (text); advisor() results are unwrapped from {type, text}
@@ -83,7 +83,7 @@ const HOOK_EVENTS_SCHEMA: &str = r#"hook_events
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   timestamp           VARCHAR   ISO 8601 timestamp string
   hook_event          VARCHAR   Hook event name (e.g. 'SessionStart', 'PreToolUse', 'PostToolUse')
   hook_name           VARCHAR   Specific hook identifier (e.g. 'SessionStart:startup', 'PreToolUse:Bash')
@@ -98,7 +98,7 @@ const SESSIONS_SCHEMA: &str = r#"sessions
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   started_at          VARCHAR   Timestamp of first message
   ended_at            VARCHAR   Timestamp of last message
   message_count       BIGINT    Total messages in session
@@ -179,7 +179,7 @@ messages
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name (directory containing the JSONL file)
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   uuid                VARCHAR   Message UUID
   parent_uuid         VARCHAR   Parent message UUID
   type                VARCHAR   'user' or 'assistant'
@@ -197,7 +197,7 @@ tool_calls
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   message_uuid        VARCHAR   UUID of the containing assistant message
   tool_use_id         VARCHAR   Unique tool use ID (matches tool_results.tool_use_id)
   name                VARCHAR   Tool name (e.g. 'Bash', 'Read', 'Edit', 'Skill')
@@ -217,7 +217,7 @@ tool_results
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   tool_use_id         VARCHAR   Matches tool_calls.tool_use_id
   is_error            BOOLEAN   true if the tool call returned an error
   content             VARCHAR   Tool result content (text); advisor() results are unwrapped from {type, text}
@@ -231,7 +231,7 @@ hook_events
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   timestamp           VARCHAR   ISO 8601 timestamp string
   hook_event          VARCHAR   Hook event name (e.g. 'SessionStart', 'PreToolUse', 'PostToolUse')
   hook_name           VARCHAR   Specific hook identifier (e.g. 'SessionStart:startup', 'PreToolUse:Bash')
@@ -246,7 +246,7 @@ sessions
   session_id          VARCHAR   Session identifier
   project             VARCHAR   Project name
   source              VARCHAR   Source the transcript came from (`main` or a cenv env name)
-  harness             VARCHAR   The tool that produced the transcript (claude, opencode)
+  harness             VARCHAR   The tool that produced the transcript (claude, codex, opencode)
   started_at          VARCHAR   Timestamp of first message
   ended_at            VARCHAR   Timestamp of last message
   message_count       BIGINT    Total messages in session

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -136,6 +136,10 @@ pub fn run(
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -248,6 +252,10 @@ fn run_with_fields(
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -304,6 +312,10 @@ fn run_count_by(
     if let Some(source) = &scope.source {
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
+    }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/commands/tools.rs
+++ b/src/commands/tools.rs
@@ -129,6 +129,10 @@ pub fn run(
         conditions.push(crate::scope::source_filter_sql("tc."));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql("tc."));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -290,6 +294,9 @@ fn run_with_context(
     if scope.source.is_some() {
         scope_conditions.push(crate::scope::source_filter_sql(""));
     }
+    if scope.harness.is_some() {
+        scope_conditions.push(crate::scope::harness_filter_sql(""));
+    }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
         scope_conditions.push(format!("timestamp >= '{formatted}'"));
@@ -308,6 +315,9 @@ fn run_with_context(
     }
     if scope.source.is_some() {
         tool_conditions.push(crate::scope::source_filter_sql("tc."));
+    }
+    if scope.harness.is_some() {
+        tool_conditions.push(crate::scope::harness_filter_sql("tc."));
     }
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -554,6 +564,10 @@ fn run_count_by(
         conditions.push(crate::scope::source_filter_sql("tc."));
         params.push(Box::new(source.clone()));
     }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql("tc."));
+        params.push(Box::new(harness.clone()));
+    }
 
     if let Some(ts) = scope.since_timestamp()? {
         let formatted = ts.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -646,6 +660,10 @@ fn run_summary(
     if let Some(source) = &scope.source {
         conditions.push(crate::scope::source_filter_sql(""));
         params.push(Box::new(source.clone()));
+    }
+    if let Some(harness) = &scope.harness {
+        conditions.push(crate::scope::harness_filter_sql(""));
+        params.push(Box::new(harness.clone()));
     }
 
     if let Some(ts) = scope.since_timestamp()? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,10 +252,11 @@ fn main() -> Result<()> {
 
     // Auto-scope to current project if no explicit --project and not --all
     let is_projects_cmd = matches!(cli.command, Command::Projects { .. });
+    let is_sql_cmd = matches!(cli.command, Command::Sql { .. });
 
     let (project, auto_scoped) = if cli.project.is_some() {
         (cli.project, false)
-    } else if cli.all || cli.json || is_projects_cmd {
+    } else if cli.all || cli.json || is_projects_cmd || is_sql_cmd {
         (None, false)
     } else {
         match std::env::var("PWD").ok() {
@@ -281,7 +282,7 @@ fn main() -> Result<()> {
     // session identifiers. --all intentionally spans harnesses.
     let (harness, harness_auto) = if let Some(harness) = cli.harness.as_ref() {
         (Some(harness.as_str().to_string()), false)
-    } else if cli.all {
+    } else if cli.all || is_sql_cmd {
         (None, false)
     } else {
         let active = cq::scope::active_harness();
@@ -299,7 +300,12 @@ fn main() -> Result<()> {
     // (the one matching CLAUDE_CONFIG_DIR), unless --all/--json/projects.
     let (source, source_auto) = if cli.source.is_some() {
         (cli.source.clone(), false)
-    } else if cli.all || cli.json || is_projects_cmd || harness.as_deref() == Some("codex") {
+    } else if cli.all
+        || cli.json
+        || is_projects_cmd
+        || is_sql_cmd
+        || harness.as_deref() == Some("codex")
+    {
         (None, false)
     } else {
         let active = std::env::var("CLAUDE_CONFIG_DIR")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,28 @@
 use std::io::IsTerminal;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use cq::claude_provider::ClaudeProvider;
 use cq::codex_provider::CodexProvider;
 use cq::commands::{hooks, messages, projects, schema, sessions, sql, tools};
 use cq::db;
 use cq::output::OutputFormat;
 use cq::scope::QueryScope;
+
+#[derive(Clone, Debug, ValueEnum)]
+enum Harness {
+    Claude,
+    Codex,
+}
+
+impl Harness {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -56,9 +71,13 @@ struct Cli {
     #[arg(long, global = true)]
     all: bool,
 
-    /// Scope to a named source (e.g. 'main', or a cenv env name). Spans all sources with --all.
+    /// Scope to a named Claude source (e.g. 'main', or a cenv env name)
     #[arg(long, global = true)]
     source: Option<String>,
+
+    /// Scope to a transcript harness (claude or codex)
+    #[arg(long, global = true, value_enum, conflicts_with = "source")]
+    harness: Option<Harness>,
 
     /// Maximum number of results (0 for unlimited)
     #[arg(long, global = true, default_value_t = 50)]
@@ -258,11 +277,29 @@ fn main() -> Result<()> {
         }
     }
 
+    // Harness scope: explicit --harness wins; else infer Codex from its runtime
+    // session identifiers. --all intentionally spans harnesses.
+    let (harness, harness_auto) = if let Some(harness) = cli.harness.as_ref() {
+        (Some(harness.as_str().to_string()), false)
+    } else if cli.all {
+        (None, false)
+    } else {
+        let active = cq::scope::active_harness();
+        let inferred = active.is_some();
+        (active, inferred)
+    };
+    if harness_auto && !cli.json {
+        eprintln!(
+            "{}",
+            cq::style::hint("Scoped to harness 'codex' (use --all to span harnesses)")
+        );
+    }
+
     // Source scope: explicit --source wins; else auto-scope to the active source
     // (the one matching CLAUDE_CONFIG_DIR), unless --all/--json/projects.
     let (source, source_auto) = if cli.source.is_some() {
         (cli.source.clone(), false)
-    } else if cli.all || cli.json || is_projects_cmd {
+    } else if cli.all || cli.json || is_projects_cmd || harness.as_deref() == Some("codex") {
         (None, false)
     } else {
         let active = std::env::var("CLAUDE_CONFIG_DIR")
@@ -283,7 +320,9 @@ fn main() -> Result<()> {
         }
     }
 
-    let scope = QueryScope::new(project, cli.session, cli.since).with_source(source);
+    let scope = QueryScope::new(project, cli.session, cli.since)
+        .with_source(source)
+        .with_harness(harness);
 
     let sync_mode = if cli.reindex {
         db::SyncMode::Force

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -31,6 +31,7 @@ pub struct QueryScope {
     pub session: Option<String>,
     pub since: Option<String>,
     pub source: Option<String>,
+    pub harness: Option<String>,
 }
 
 impl QueryScope {
@@ -40,12 +41,19 @@ impl QueryScope {
             session,
             since,
             source: None,
+            harness: None,
         }
     }
 
     /// Set the source filter (builder style so existing `new` callers are untouched).
     pub fn with_source(mut self, source: Option<String>) -> Self {
         self.source = source;
+        self
+    }
+
+    /// Set the transcript harness filter (for example, `claude` or `codex`).
+    pub fn with_harness(mut self, harness: Option<String>) -> Self {
+        self.harness = harness;
         self
     }
 
@@ -82,11 +90,34 @@ impl QueryScope {
     }
 }
 
-/// SQL predicate for CQ's Claude-only `--source` dimension. Other harnesses
-/// do not have Claude sources, so they remain in scope when a source is chosen.
+/// SQL predicate for CQ's Claude-only `--source` dimension.
 /// `prefix` is an optional relation prefix such as `"tc."`.
 pub fn source_filter_sql(prefix: &str) -> String {
-    format!("({prefix}harness != 'claude' OR {prefix}source = ?)")
+    format!("{prefix}source = ?")
+}
+
+/// SQL predicate for CQ's top-level transcript harness dimension.
+/// `prefix` is an optional relation prefix such as `"tc."`.
+pub fn harness_filter_sql(prefix: &str) -> String {
+    format!("{prefix}harness = ?")
+}
+
+/// True when the process is running inside a Codex session. Either variable is
+/// sufficient because the Codex runtime has used both identifiers.
+pub fn is_codex_runtime(session_id: Option<&str>, thread_id: Option<&str>) -> bool {
+    [session_id, thread_id]
+        .into_iter()
+        .flatten()
+        .any(|value| !value.is_empty())
+}
+
+/// Return the active harness inferred from runtime metadata, if any.
+pub fn active_harness() -> Option<String> {
+    is_codex_runtime(
+        std::env::var("CODEX_SESSION_ID").ok().as_deref(),
+        std::env::var("CODEX_THREAD_ID").ok().as_deref(),
+    )
+    .then(|| "codex".to_string())
 }
 
 #[cfg(test)]
@@ -150,5 +181,13 @@ mod tests {
     #[test]
     fn validate_session_id_empty() {
         assert!(validate_session_id("").is_err());
+    }
+
+    #[test]
+    fn detects_codex_runtime_from_either_identifier() {
+        assert!(is_codex_runtime(Some("session"), None));
+        assert!(is_codex_runtime(None, Some("thread")));
+        assert!(!is_codex_runtime(Some(""), Some("")));
+        assert!(!is_codex_runtime(None, None));
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -197,6 +197,17 @@ fn harness_and_source_cannot_be_combined() {
 }
 
 #[test]
+fn raw_sql_does_not_claim_automatic_scope() {
+    let env = setup_codex_env();
+    cq_cmd(&env)
+        .env("CODEX_SESSION_ID", "test-codex-session")
+        .args(["sql", "SELECT count(*) AS sessions FROM sessions"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Scoped to harness").not());
+}
+
+#[test]
 fn sessions_table() {
     let env = setup_env(&["simple_session.jsonl"]);
     cq_cmd(&env)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -40,6 +40,10 @@ fn cq_cmd(env: &TestEnv) -> Command {
     cmd.env("CQ_CODEX_SESSIONS_DIR", env.codex_sessions.path());
     // Isolate from any real cenv envs on the host so only CQ_PROJECTS_DIR is indexed.
     cmd.env("CENV_BASE", env.cache.path().join("no-such-cenv-base"));
+    // Test commands should exercise their chosen runtime explicitly, rather
+    // than inheriting the Codex session that happens to run the test suite.
+    cmd.env_remove("CODEX_SESSION_ID");
+    cmd.env_remove("CODEX_THREAD_ID");
     cmd.env("NO_COLOR", "1");
     cmd
 }
@@ -127,9 +131,8 @@ fn sessions_list() {
 fn codex_sessions_and_tools_are_queryable() {
     let env = setup_codex_env();
 
-    // The normal default source scope is Claude-only; Codex remains visible
-    // because it has no Claude source dimension.
     cq_cmd(&env)
+        .env("CODEX_SESSION_ID", "test-codex-session")
         .arg("sessions")
         .assert()
         .success()
@@ -145,6 +148,52 @@ fn codex_sessions_and_tools_are_queryable() {
         .stdout(predicate::str::contains("codex"))
         .stdout(predicate::str::contains("codex-project"))
         .stdout(predicate::str::contains("2"));
+}
+
+#[test]
+fn codex_runtime_scopes_to_codex_unless_all_is_requested() {
+    let env = setup_env(&["simple_session.jsonl"]);
+    let rollout_dir = env.codex_sessions.path().join("2026/08/26");
+    std::fs::create_dir_all(&rollout_dir).unwrap();
+    std::fs::copy(
+        fixture_path("codex_session.jsonl"),
+        rollout_dir.join("rollout-2026-08-26T14-00-00-session.jsonl"),
+    )
+    .unwrap();
+
+    cq_cmd(&env)
+        .env("CODEX_THREAD_ID", "test-codex-thread")
+        .arg("sessions")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("019a1b2c"))
+        .stdout(predicate::str::contains("sess-001").not());
+
+    cq_cmd(&env)
+        .env("CODEX_THREAD_ID", "test-codex-thread")
+        .args(["--json", "sessions"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("019a1b2c"))
+        .stdout(predicate::str::contains("sess-001").not());
+
+    cq_cmd(&env)
+        .env("CODEX_THREAD_ID", "test-codex-thread")
+        .args(["--all", "sessions"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("019a1b2c"))
+        .stdout(predicate::str::contains("sess-001"));
+}
+
+#[test]
+fn harness_and_source_cannot_be_combined() {
+    let env = setup_env(&[]);
+    cq_cmd(&env)
+        .args(["--harness", "codex", "--source", "main", "sessions"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]
@@ -2030,6 +2079,8 @@ fn multi_cmd(env: &MultiSourceEnv) -> Command {
         env.cache.path().join("no-such-codex-sessions"),
     );
     cmd.env("CENV_BASE", env.cenv_base.path());
+    cmd.env_remove("CODEX_SESSION_ID");
+    cmd.env_remove("CODEX_THREAD_ID");
     cmd.env("NO_COLOR", "1");
     cmd
 }


### PR DESCRIPTION
## Summary
- infer the Codex harness from Codex runtime session metadata
- add an explicit `--harness claude|codex` filter and keep `--source` Claude-only
- avoid automatic scope hints for raw SQL, which intentionally remains unscoped

## Testing
- `cargo test`
- verified live Codex-runtime, explicit Claude, and mixed-harness queries