### PR TITLE
docs(trace): document args.detail on tool spans and gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Add `--perfetto` to emit Chrome Trace Event JSON on stdout instead of the waterf
 cq trace --session <id> --perfetto > trace.json
 ```
 
+Tool spans and "blocked on you" gaps carry a compact `args.detail` string too (the tool's input, or the message that ended the gap, truncated at 200 chars) — Firefox Profiler renders it straight into the Marker Chart, Marker Table, and tooltip with no click needed; Perfetto shows the full `args` object regardless.
+
 The global `--json` flag returns span rows instead of either renderer: one object per paired tool call, with `lane`, `duration_ms`, and `is_error`.
 
 ## Use cases

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cq",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Query past Claude Code sessions via the cq CLI (SQL over session transcripts). Teaches Claude when and how to invoke cq to answer questions about session history, tool usage, errors, and past commands.",
   "author": {
     "name": "Josh Nichols",

--- a/claude-plugin/CLAUDE.md
+++ b/claude-plugin/CLAUDE.md
@@ -1,0 +1,25 @@
+# claude-plugin/
+
+This directory is packaged and distributed as a Claude Code plugin (marketplace
+installs point here, not at the repo root). It has its own version, independent
+of the `cq` binary's version in `../Cargo.toml`.
+
+## Bump the plugin version on every skill-file change
+
+Any commit that changes `skills/cq/SKILL.md` must also bump `version` in
+`.claude-plugin/plugin.json`, patch-level, in the same commit or an immediately
+following one: `chore(plugin): bump version to X for skill doc update`. See
+`git log -- claude-plugin/.claude-plugin/plugin.json` for the pattern.
+
+**Why:** the marketplace/plugin install mechanism resolves and caches by this
+version. A SKILL.md edit that lands without a bump is invisible to already-installed
+copies of the plugin (`~/.claude/plugins/cache/pickled-claude-plugins/cq/<old-version>/`
+keeps serving the stale skill text), so the fix or doc update silently doesn't
+reach anyone until some unrelated change finally bumps it.
+
+This applies to *behavior* changes to the skill's instructions: new flags,
+changed output shape, new gotchas, corrected guidance. Typo fixes with no
+change in meaning don't need a bump.
+
+`README.md` in this directory is not skill-instruction content served to an
+agent mid-session, so changing it alone doesn't require a bump.

--- a/claude-plugin/skills/cq/SKILL.md
+++ b/claude-plugin/skills/cq/SKILL.md
@@ -40,7 +40,7 @@ user_invocable: true
 - **search**: `--type user|assistant`, `--all-matches` (every matching message rather than the best one per session)
 - **tools**: `--grep` (filter inputs, repeatable/OR), `--result-grep` (filter by tool result content, repeatable/OR, ANDs with `--errors`), `--errors` (errors only), `--fields` (extract input fields as columns)
 - **messages**: `--type user|assistant`, `--grep` (repeatable/OR)
-- **trace**: `--session <ID>` (required), `--from`/`--to` (zoom into a time window), `--perfetto` (emit Chrome Trace Event JSON instead of the waterfall)
+- **trace**: `--session <ID>` (required), `--from`/`--to` (zoom into a time window), `--perfetto` (emit Chrome Trace Event JSON instead of the waterfall). `--perfetto` output's tool spans and "blocked on you" gaps carry an `args.detail` string (tool input, or the gap-closing message, truncated at 200 chars) so it renders directly in Firefox Profiler without a click.
 
 ## View Schemas
 


### PR DESCRIPTION
## Summary
- `--perfetto` tool spans and "blocked on you" gaps have carried an `args.detail` string since #46/#47 (tool input, or the gap-closing message, truncated at 200 chars) so Firefox Profiler renders them without a click
- Neither README nor the skill doc mentioned it, so this documents the already-shipped behavior
- Bumps the plugin version (0.3.4 → 0.3.5) since this changes `SKILL.md`, per the existing (now-documented) convention
- Adds `claude-plugin/CLAUDE.md` writing down that version-bump-per-skill-change convention, which previously only existed as a pattern in git history

## Test plan
- [x] Docs-only change, no code touched